### PR TITLE
fix: improve error handling in object service and views

### DIFF
--- a/backend/apps/objects/views.py
+++ b/backend/apps/objects/views.py
@@ -3,12 +3,11 @@ from django.http import JsonResponse
 from django.views import View
 from django.utils.decorators import method_decorator
 from .models import Object, ObjectRental
-from django.shortcuts import get_object_or_404
 from django.db.utils import IntegrityError
 from django.contrib.auth import get_user_model
 from django.views.decorators.csrf import csrf_exempt
 from apps.common.utils.jwt_auth import resolve_user_from_request
-from django.db.models import Q, Count
+from django.db.models import Q
 
 @method_decorator(csrf_exempt, name='dispatch')
 class AuthenticatedView(View):
@@ -64,9 +63,21 @@ class ObjectListView(AuthenticatedView):
         except Exception as e:
             return JsonResponse({"detail": str(e)}, status=400)
 
+
+def get_residence_object(request, object_id):
+    if not hasattr(request, 'residence') or not request.residence:
+        return None, JsonResponse({"detail": "No residence context."}, status=400)
+    try:
+        return Object.objects.get(id=object_id, residence=request.residence), None
+    except Object.DoesNotExist:
+        return None, JsonResponse({"detail": "Objeto no encontrado."}, status=404)
+
+
 class ObjectDetailView(AuthenticatedView):
     def get(self, request, object_id):
-        obj = get_object_or_404(Object, id=object_id, residence=request.residence)
+        obj, error_response = get_residence_object(request, object_id)
+        if error_response:
+            return error_response
         rentals_count = obj.rentals.count()
         return JsonResponse({
             'id': obj.id,
@@ -81,15 +92,24 @@ class ObjectDetailView(AuthenticatedView):
         })
 
     def delete(self, request, object_id):
-        obj = get_object_or_404(Object, id=object_id, residence=request.residence)
+        obj, error_response = get_residence_object(request, object_id)
+        if error_response:
+            return error_response
         if not request.user.is_staff:
             return JsonResponse({"detail": "Unauthorized"}, status=403)
-        obj.delete()
-        return JsonResponse({"detail": "Object deleted"}, status=204)
+        try:
+            obj.delete()
+            return JsonResponse({"detail": "Object deleted"}, status=200)
+        except IntegrityError:
+            return JsonResponse({"detail": "No se puede eliminar el objeto por dependencias activas."}, status=400)
+        except Exception as e:
+            return JsonResponse({"detail": str(e)}, status=500)
 
 class ObjectReserveView(AuthenticatedView):
     def post(self, request, object_id):
-        obj = get_object_or_404(Object, id=object_id, residence=request.residence)
+        obj, error_response = get_residence_object(request, object_id)
+        if error_response:
+            return error_response
         try:
             body = json.loads(request.body)
             start = body.get('start_date')
@@ -120,7 +140,9 @@ class ObjectReserveView(AuthenticatedView):
 
 class ObjectCancelView(AuthenticatedView):
     def post(self, request, object_id):
-        obj = get_object_or_404(Object, id=object_id, residence=request.residence)
+        obj, error_response = get_residence_object(request, object_id)
+        if error_response:
+            return error_response
         try:
             body = json.loads(request.body) if request.body else {}
             # try to cancel specific rental id
@@ -139,7 +161,9 @@ class ObjectCancelView(AuthenticatedView):
 
 class ObjectRentalsView(AuthenticatedView):
     def get(self, request, object_id):
-        obj = get_object_or_404(Object, id=object_id, residence=request.residence)
+        obj, error_response = get_residence_object(request, object_id)
+        if error_response:
+            return error_response
         rentals = obj.rentals.select_related('user').all()
         data = []
         for r in rentals:

--- a/frontend/src/services/objects.ts
+++ b/frontend/src/services/objects.ts
@@ -3,6 +3,27 @@ import { API_URL } from "./api";
 
 const OBJECTS_URL = `${API_URL}/objects`;
 
+async function buildApiError(response: Response, fallbackMessage: string): Promise<Error> {
+  try {
+    const contentType = response.headers.get("content-type") || "";
+
+    if (contentType.includes("application/json")) {
+      const payload = await response.json();
+      const detail = typeof payload?.detail === "string" ? payload.detail : "";
+      return new Error(detail || `${fallbackMessage} (HTTP ${response.status})`);
+    }
+
+    const rawText = (await response.text()).trim();
+    if (rawText && !rawText.startsWith("<")) {
+      return new Error(rawText);
+    }
+  } catch {
+    // Fall back to a generic message when body parsing fails.
+  }
+
+  return new Error(`${fallbackMessage} (HTTP ${response.status})`);
+}
+
 export interface ObjectRental {
   id: number;
   start_date: string;
@@ -58,8 +79,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al obtener objetos');
+      throw await buildApiError(response, 'Error al obtener objetos');
     }
     
     return response.json();
@@ -74,8 +94,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al obtener detalles del objeto');
+      throw await buildApiError(response, 'Error al obtener detalles del objeto');
     }
     
     return response.json();
@@ -91,8 +110,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al crear objeto');
+      throw await buildApiError(response, 'Error al crear objeto');
     }
     
     return response.json();
@@ -107,8 +125,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al eliminar objeto');
+      throw await buildApiError(response, 'Error al eliminar objeto');
     }
   },
 
@@ -122,8 +139,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al reservar objeto');
+      throw await buildApiError(response, 'Error al reservar objeto');
     }
     
     return response.json();
@@ -139,8 +155,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al cancelar reserva');
+      throw await buildApiError(response, 'Error al cancelar reserva');
     }
     
     return response.json();
@@ -155,8 +170,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al obtener reservas del objeto');
+      throw await buildApiError(response, 'Error al obtener reservas del objeto');
     }
     
     return response.json();
@@ -171,8 +185,7 @@ export const objectsService = {
     });
     
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(errorData.detail || 'Error al obtener mis reservas');
+      throw await buildApiError(response, 'Error al obtener mis reservas');
     }
     
     return response.json();


### PR DESCRIPTION
This pull request improves error handling and code consistency for both the backend and frontend object management features. On the backend, it introduces a helper to standardize object lookup and error responses, and enhances deletion error handling. On the frontend, it centralizes API error parsing to provide more informative and consistent error messages to users.

**Backend improvements:**

* Introduced a `get_residence_object` helper function to standardize object retrieval and error responses, replacing repeated use of `get_object_or_404` in multiple views (`ObjectDetailView`, `ObjectReserveView`, `ObjectCancelView`, `ObjectRentalsView`). [[1]](diffhunk://#diff-24e0e7919105886ba295a45392bb955870ef3cbae63ab1203fcecc91ba26a902R66-R80) [[2]](diffhunk://#diff-24e0e7919105886ba295a45392bb955870ef3cbae63ab1203fcecc91ba26a902L84-R112) [[3]](diffhunk://#diff-24e0e7919105886ba295a45392bb955870ef3cbae63ab1203fcecc91ba26a902L123-R145) [[4]](diffhunk://#diff-24e0e7919105886ba295a45392bb955870ef3cbae63ab1203fcecc91ba26a902L142-R166)
* Improved error handling in the object deletion endpoint: now catches `IntegrityError` for dependent objects and returns appropriate status codes and messages.
* Removed unused imports for cleaner code.

**Frontend improvements:**

* Added a `buildApiError` helper function to parse API error responses, supporting both JSON and plain text, and providing fallback messages.
* Updated all methods in `objectsService` to use `buildApiError` for consistent and user-friendly error reporting across object-related API calls. [[1]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L61-R82) [[2]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L77-R97) [[3]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L94-R113) [[4]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L110-R128) [[5]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L125-R142) [[6]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L142-R158) [[7]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L158-R173) [[8]](diffhunk://#diff-f3c93a2aeff0b25ad75ea55801bbd8743529552c0437e4daf46527d9bce8f371L174-R188)