### PR TITLE
feat: ver detalle de habitación desde menú de administrador [NX-S2.03]

### DIFF
--- a/backend/apps/bedrooms/serializers.py
+++ b/backend/apps/bedrooms/serializers.py
@@ -6,6 +6,7 @@ from .models import Bedroom
 class BedroomResidentSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     full_name = serializers.CharField()
+    email = serializers.EmailField(allow_null=True)
 
 
 class BedroomSerializer(serializers.ModelSerializer):
@@ -49,6 +50,7 @@ class BedroomSerializer(serializers.ModelSerializer):
             {
                 "id": resident.id,
                 "full_name": resident.user.get_full_name().strip() or resident.user.username,
+                "email": getattr(resident.user, "email", None),
             }
             for resident in residents
         ]

--- a/backend/apps/bedrooms/tests/test_bedroom_residents_detail.py
+++ b/backend/apps/bedrooms/tests/test_bedroom_residents_detail.py
@@ -1,0 +1,197 @@
+from django.contrib.auth import get_user_model
+from django_tenants.test.cases import FastTenantTestCase
+from django_tenants.test.client import TenantClient
+
+from apps.bedrooms.models import Bedroom
+from apps.membership.models import Membership, Role
+from apps.residences.models import Residence, ResidenceDomain
+
+
+class BedroomDetailViewTests(FastTenantTestCase):
+    @classmethod
+    def get_test_tenant_domain(cls):
+        return "bedrooms.test.local"
+
+    @classmethod
+    def setup_tenant(cls, tenant):
+        tenant.name = "Tenant Bedrooms Test"
+        tenant.slug = "tenant-bedrooms-test"
+        tenant.is_active = True
+        tenant.on_trial = True
+
+    @classmethod
+    def setup_domain(cls, domain):
+        domain.domain = cls.get_test_tenant_domain()
+        domain.is_primary = True
+
+    def setUp(self):
+        super().setUp()
+        user_model = get_user_model()
+
+        self.admin_user = user_model.objects.create_user(
+            username="admin-bed",
+            email="admin@bedrooms.test",
+            password="demo1234",  # NOSONAR
+            first_name="Admin",
+            last_name="Bed",
+            is_staff=True,
+        )
+        self.student_user = user_model.objects.create_user(
+            username="student-bed",
+            email="student@bedrooms.test",
+            password="demo1234",  # NOSONAR
+            first_name="Carlos",
+            last_name="Ruiz",
+        )
+        self.other_student_user = user_model.objects.create_user(
+            username="student-bed-2",
+            email="student2@bedrooms.test",
+            password="demo1234",  # NOSONAR
+            first_name="Ana",
+            last_name="López",
+        )
+
+        self.residence = Residence.objects.create(
+            name="Residencia Bedrooms",
+            slug="residencia-bedrooms",
+            code="RB-001",
+            timezone="Europe/Madrid",
+            is_active=True,
+        )
+        ResidenceDomain.objects.create(
+            residence=self.residence,
+            domain=self.get_test_tenant_domain(),
+            is_primary=True,
+            is_active=True,
+        )
+        self.other_residence = Residence.objects.create(
+            name="Residencia Otra",
+            slug="residencia-otra-bed",
+            code="ROB-001",
+            timezone="Europe/Madrid",
+            is_active=True,
+        )
+
+        self.student_role = Role.objects.create(
+            name="Student",
+            description="Residente",
+            is_system_default=True,
+            residence=None,
+        )
+
+        self.bedroom = Bedroom.objects.create(
+            numero="101",
+            planta=1,
+            capacidad_maxima=2,
+            tipo=Bedroom.Tipo.DOBLE,
+            residence=self.residence,
+            is_active=True,
+        )
+        self.other_bedroom = Bedroom.objects.create(
+            numero="201",
+            planta=2,
+            capacidad_maxima=1,
+            tipo=Bedroom.Tipo.INDIVIDUAL,
+            residence=self.other_residence,
+            is_active=True,
+        )
+
+        self.admin_client = TenantClient(self.tenant)
+        self.admin_client.force_login(self.admin_user)
+
+        self.anon_client = TenantClient(self.tenant)
+
+        self.non_staff_client = TenantClient(self.tenant)
+        self.non_staff_client.force_login(self.student_user)
+
+    def _url(self, bedroom_id):
+        return f"/api/bedrooms/{bedroom_id}/"
+
+    def _create_membership(self, user, bedroom=None, is_active=True, role=None):
+        return Membership.objects.create(
+            user=user,
+            role=role or self.student_role,
+            residence=self.residence,
+            bedroom=bedroom,
+            is_active=is_active,
+        )
+
+    # --- Campos del detalle ---
+
+    def test_response_includes_detail_fields(self):
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        for field in ["id", "numero", "planta", "tipo", "capacidad_maxima", "ocupantes_actuales", "residentes"]:
+            self.assertIn(field, data)
+
+    def test_residentes_is_empty_when_no_residents(self):
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["residentes"], [])
+        self.assertEqual(response.json()["ocupantes_actuales"], 0)
+
+    def test_residentes_includes_active_student(self):
+        self._create_membership(self.student_user, bedroom=self.bedroom)
+
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["residentes"]), 1)
+        self.assertEqual(data["residentes"][0]["full_name"], "Carlos Ruiz")
+
+    def test_ocupantes_actuales_matches_active_students(self):
+        self._create_membership(self.student_user, bedroom=self.bedroom)
+        self._create_membership(self.other_student_user, bedroom=self.bedroom)
+
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["ocupantes_actuales"], 2)
+        self.assertEqual(len(data["residentes"]), 2)
+
+    def test_inactive_membership_excluded_from_residentes(self):
+        self._create_membership(self.student_user, bedroom=self.bedroom, is_active=False)
+
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["residentes"], [])
+        self.assertEqual(data["ocupantes_actuales"], 0)
+
+    def test_non_student_role_excluded_from_residentes(self):
+        admin_role = Role.objects.create(
+            name="Admin",
+            description="Administrador",
+            is_system_default=False,
+            residence=self.residence,
+        )
+        self._create_membership(self.student_user, bedroom=self.bedroom, role=admin_role)
+
+        response = self.admin_client.get(self._url(self.bedroom.id))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["residentes"], [])
+
+    # --- Flujo negativo ---
+
+    def test_non_staff_is_forbidden(self):
+        response = self.non_staff_client.get(self._url(self.bedroom.id))
+        self.assertEqual(response.status_code, 403)
+
+    def test_unauthenticated_is_rejected(self):
+        response = self.anon_client.get(self._url(self.bedroom.id))
+        self.assertEqual(response.status_code, 401)
+
+    def test_bedroom_from_other_residence_returns_404(self):
+        response = self.admin_client.get(self._url(self.other_bedroom.id))
+        self.assertEqual(response.status_code, 404)
+
+    def test_nonexistent_bedroom_returns_404(self):
+        response = self.admin_client.get(self._url(99999))
+        self.assertEqual(response.status_code, 404)

--- a/backend/apps/bedrooms/tests/test_bedroom_residents_detail.py
+++ b/backend/apps/bedrooms/tests/test_bedroom_residents_detail.py
@@ -141,7 +141,10 @@ class BedroomDetailViewTests(FastTenantTestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["residentes"]), 1)
-        self.assertEqual(data["residentes"][0]["full_name"], "Carlos Ruiz")
+        residente = data["residentes"][0]
+        self.assertEqual(residente["full_name"], "Carlos Ruiz")
+        self.assertIn("email", residente)
+        self.assertEqual(residente["email"], "student@bedrooms.test")
 
     def test_ocupantes_actuales_matches_active_students(self):
         self._create_membership(self.student_user, bedroom=self.bedroom)

--- a/backend/apps/bedrooms/urls.py
+++ b/backend/apps/bedrooms/urls.py
@@ -6,6 +6,7 @@ from .views import (
 	BedroomUpdateView,
 	BedroomDeleteView,
 	BedroomResidentsView,
+	BedroomResidentsDetailView,
 	AvailableBedroomsView,
 )
 
@@ -15,6 +16,7 @@ urlpatterns = [
 	# /available/ debe ir antes de /<int:bedroom_id>/ para evitar colisión de rutas
 	path('bedrooms/available/', AvailableBedroomsView.as_view(), name='bedroom-available'),
 	path('bedrooms/residents/', BedroomResidentsView.as_view(), name='bedroom-residents'),
+	path('bedrooms/<int:bedroom_id>/residents/', BedroomResidentsDetailView.as_view(), name='bedroom-residents-detail'),
 	path('bedrooms/<int:bedroom_id>/', BedroomRetrieveView.as_view(), name='bedroom-retrieve'),
 	path('bedrooms/<int:bedroom_id>/update/', BedroomUpdateView.as_view(), name='bedroom-update'),
 	path('bedrooms/<int:bedroom_id>/delete/', BedroomDeleteView.as_view(), name='bedroom-delete'),

--- a/backend/apps/bedrooms/views.py
+++ b/backend/apps/bedrooms/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from apps.common.utils.jwt_auth import resolve_user_from_request
 from apps.membership.models import Membership
 from .models import Bedroom
-from .serializers import BedroomSerializer
+from .serializers import BedroomSerializer, ResidentSerializer
 from .services import delete_bedroom, list_available_bedrooms
 
 
@@ -141,6 +141,14 @@ class AvailableBedroomsView(AdminRequiredView):
 		exclude_param = request.GET.get("exclude_resident_id")
 		exclude_id = int(exclude_param) if exclude_param and exclude_param.isdigit() else None
 		data = list_available_bedrooms(request.residence, exclude_membership_id=exclude_id)
+		return JsonResponse(data, safe=False)
+
+
+class BedroomResidentsDetailView(AdminRequiredView):
+	def get(self, request, bedroom_id):
+		bedroom = get_object_or_404(Bedroom, id=bedroom_id, residence=request.residence)
+		qs = bedroom.residents.filter(is_active=True, role__name="Student").select_related('user')
+		data = [ResidentSerializer.from_membership(m) for m in qs]
 		return JsonResponse(data, safe=False)
 
 

--- a/frontend/src/pages/Rooms/Rooms.tsx
+++ b/frontend/src/pages/Rooms/Rooms.tsx
@@ -47,6 +47,21 @@ function validateUnidades(v: string, isEditing: boolean): string {
   return isNaN(n) || n < 1 ? "Debe ser al menos 1" : "";
 }
 
+const CAPACITY_BY_TYPE: Record<string, number> = { Individual: 1, Doble: 2, Triple: 3 };
+
+function getErrorMessage(detail: unknown, fallback: string): string {
+  if (typeof detail === "string" && detail.trim()) return detail;
+  if (Array.isArray(detail)) return detail.map(String).join(" ");
+  if (detail && typeof detail === "object") {
+    const messages = Object.values(detail as Record<string, unknown>)
+      .flatMap((v) => (Array.isArray(v) ? v : [v]))
+      .map(String)
+      .filter(Boolean);
+    if (messages.length) return messages.join(" ");
+  }
+  return fallback;
+}
+
 export function Rooms() {
   const [rooms, setRooms] = useState<Bedroom[]>([]);
   const [loading, setLoading] = useState(true);
@@ -138,18 +153,18 @@ export function Rooms() {
     validateField(k, v);
   };
 
-  const saveOneBedroom = async (payload: object) => {
+  const saveOneBedroom = async (payload: Record<string, unknown>) => {
     if (isEditing && editingId) {
       const res = await updateBedroom(editingId, payload);
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error((body as { detail?: string }).detail || `Error ${res.status}`);
+        throw new Error(getErrorMessage((body as { detail?: unknown }).detail, `Error ${res.status}`));
       }
     } else {
       const res = await createBedroom(payload);
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        throw new Error((body as { detail?: string }).detail || `Error ${res.status}`);
+        throw new Error(getErrorMessage((body as { detail?: unknown }).detail, `Error ${res.status}`));
       }
     }
   };
@@ -167,7 +182,7 @@ export function Rooms() {
       planta: form.planta ? Number.parseInt(form.planta) : null,
       edificio: form.edificio,
       tipo: form.tipo,
-      capacidad_maxima: form.tipo === "Individual" ? 1 : form.tipo === "Doble" ? 2 : 3,
+      capacidad_maxima: CAPACITY_BY_TYPE[form.tipo] ?? 1,
     };
 
     try {
@@ -195,6 +210,20 @@ export function Rooms() {
     });
     setErrors({});
     setIsEditing(false);
+    setIsModalOpen(true);
+  };
+
+  const openEdit = (room: Bedroom) => {
+    setEditingId(room.id);
+    setForm({
+      numero: room.numero,
+      edificio: room.edificio,
+      planta: room.planta == null ? "" : String(room.planta),
+      tipo: room.tipo,
+      unidades: 1,
+    });
+    setErrors({});
+    setIsEditing(true);
     setIsModalOpen(true);
   };
 
@@ -289,20 +318,18 @@ export function Rooms() {
                 </Badge>
 
                 <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-[#4A7C59] hover:bg-[#4A7C59]/10"
+                  onClick={() => setSelectedRoom(r)}
+                >
+                  Ver detalles
+                </Button>
+
+                <Button
                   variant="outline"
-                  onClick={() => {
-                    setEditingId(r.id);
-                    setForm({
-                      numero: r.numero,
-                      edificio: r.edificio,
-                      planta: r.planta != null ? String(r.planta) : "",
-                      tipo: r.tipo,
-                      unidades: 1,
-                    });
-                    setErrors({});
-                    setIsEditing(true);
-                    setIsModalOpen(true);
-                  }}
+                  onClick={() => openEdit(r)}
                 >
                   <Edit2 className="w-4 h-4 mr-2" />Editar
                 </Button>
@@ -372,7 +399,7 @@ export function Rooms() {
         </div>
       )}
 
-      {/* Detalle habitación (mapa) */}
+      {/* Detalle habitación */}
       {selectedRoom && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div role="button" tabIndex={-1} aria-label="Cerrar detalle" className="fixed inset-0 bg-black/50" onClick={() => setSelectedRoom(null)} onKeyDown={(e) => { if (e.key === "Escape" || e.key === "Enter") setSelectedRoom(null); }} />
@@ -399,20 +426,14 @@ export function Rooms() {
                 <p className="text-[10px] uppercase tracking-wider text-gray-500 font-bold mb-1">Estado</p>
                 <Badge className={getRoomState(selectedRoom.ocupantes_actuales, selectedRoom.capacidad_maxima).badgeClass}>{getRoomState(selectedRoom.ocupantes_actuales, selectedRoom.capacidad_maxima).label}</Badge>
               </div>
+              <div className="col-span-2 bg-gray-50 p-3 rounded-xl border border-gray-100">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500 font-bold mb-2">Residentes</p>
+                <ResidentsInlineList residents={selectedRoom.residentes} showEmail />
+              </div>
             </div>
             <Button className="w-full mt-4" variant="outline" onClick={() => {
               setSelectedRoom(null);
-              setEditingId(selectedRoom.id);
-              setForm({
-                numero: selectedRoom.numero,
-                edificio: selectedRoom.edificio,
-                planta: selectedRoom.planta === null ? "" : String(selectedRoom.planta),
-                tipo: selectedRoom.tipo,
-                unidades: 1,
-              });
-              setErrors({});
-              setIsEditing(true);
-              setIsModalOpen(true);
+              openEdit(selectedRoom);
             }}>
               <Edit2 className="w-4 h-4 mr-2" />Editar habitación
             </Button>
@@ -532,9 +553,9 @@ function groupByBuildingAndFloor(rooms: Bedroom[]): Record<string, Record<number
 }
 
 const ROOM_STATES = {
-  full:    { label: "Completa", badgeClass: "bg-red-100 text-red-700 border-0",    cellClass: "bg-red-50 border-red-400 hover:bg-red-100",       iconClass: "text-red-500",    textClass: "text-red-700" },
+  full:    { label: "Completa", badgeClass: "bg-red-100 text-red-700 border-0",       cellClass: "bg-red-50 border-red-400 hover:bg-red-100",       iconClass: "text-red-500",    textClass: "text-red-700" },
   partial: { label: "Parcial",  badgeClass: "bg-yellow-100 text-yellow-700 border-0", cellClass: "bg-yellow-50 border-yellow-400 hover:bg-yellow-100", iconClass: "text-yellow-600", textClass: "text-yellow-700" },
-  free:    { label: "Libre",    badgeClass: "bg-green-100 text-green-700 border-0", cellClass: "bg-green-50 border-green-400 hover:bg-green-100",  iconClass: "text-green-600",  textClass: "text-green-700" },
+  free:    { label: "Libre",    badgeClass: "bg-green-100 text-green-700 border-0",   cellClass: "bg-green-50 border-green-400 hover:bg-green-100",  iconClass: "text-green-600",  textClass: "text-green-700" },
 } as const;
 
 function getRoomState(ocupantes: number, capacidad: number) {
@@ -597,33 +618,23 @@ function Stat({ title, value }: Readonly<StatProps>) {
   );
 }
 
-function ResidentsInlineList({ residents }: { residents: BedroomResident[] }) {
+function ResidentsInlineList({ residents, showEmail = false }: { readonly residents: BedroomResident[]; readonly showEmail?: boolean }) {
   if (residents.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">Sin residentes asignados</p>
-    );
-  }
-
-  if (residents.length === 1) {
-    return (
-      <p
-        className="text-sm text-foreground truncate"
-        title={residents[0].full_name}
-      >
-        {residents[0].full_name}
-      </p>
+      <p className="text-sm text-muted-foreground">No hay residentes asignados</p>
     );
   }
 
   return (
     <ul className="min-w-0 space-y-0.5">
       {residents.map((resident) => (
-        <li
-          key={resident.id}
-          className="text-sm text-foreground truncate"
-          title={resident.full_name}
-        >
-          {resident.full_name}
+        <li key={resident.id} className="min-w-0">
+          <p className="text-sm text-foreground truncate" title={resident.full_name}>
+            {resident.full_name}
+          </p>
+          {showEmail && resident.email && (
+            <p className="text-xs text-muted-foreground truncate">{resident.email}</p>
+          )}
         </li>
       ))}
     </ul>

--- a/frontend/src/pages/Rooms/Rooms.tsx
+++ b/frontend/src/pages/Rooms/Rooms.tsx
@@ -294,7 +294,8 @@ export function Rooms() {
           {filteredRooms.map((r) => (
           <Card
             key={r.id}
-            className={`hover:shadow-md transition ${!r.is_active ? 'border-destructive/30 bg-destructive/5' : 'bg-card'} `}
+            className={`hover:shadow-md transition cursor-pointer ${!r.is_active ? 'border-destructive/30 bg-destructive/5' : 'bg-card'} `}
+            onClick={() => setSelectedRoom(r)}
           >
             <CardContent className="flex justify-between items-start gap-4 p-4">
               <div className="min-w-0 flex-1">
@@ -318,25 +319,16 @@ export function Rooms() {
                 </Badge>
 
                 <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="text-[#4A7C59] hover:bg-[#4A7C59]/10"
-                  onClick={() => setSelectedRoom(r)}
-                >
-                  Ver detalles
-                </Button>
-
-                <Button
                   variant="outline"
-                  onClick={() => openEdit(r)}
+                  onClick={(e) => { e.stopPropagation(); openEdit(r); }}
                 >
                   <Edit2 className="w-4 h-4 mr-2" />Editar
                 </Button>
 
                 <Button
                   variant="destructive"
-                  onClick={async () => {
+                  onClick={async (e) => {
+                    e.stopPropagation();
                     if (!confirm("¿Eliminar habitación?")) return;
                     try {
                       const res = await deleteBedroom(r.id);

--- a/frontend/src/services/bedrooms.ts
+++ b/frontend/src/services/bedrooms.ts
@@ -53,14 +53,14 @@ export async function listAvailableBedrooms(excludeResidentId?: number): Promise
     return res.json();
 }
 
-export async function createBedroom(payload: any) {
+export async function createBedroom(payload: Record<string, unknown>) {
     return fetchWithAuth(`${BASE}create/`, {
         method: 'POST',
         body: JSON.stringify(payload),
     });
 }
 
-export async function updateBedroom(id: number, payload: any) {
+export async function updateBedroom(id: number, payload: Record<string, unknown>) {
     return fetchWithAuth(`${BASE}${id}/update/`, {
         method: 'PUT',
         body: JSON.stringify(payload),
@@ -71,6 +71,20 @@ export async function deleteBedroom(id: number) {
     return fetchWithAuth(`${BASE}${id}/delete/`, {
         method: 'DELETE',
     });
+}
+
+export interface BedroomResident {
+    id: number;
+    user_id: number;
+    full_name: string;
+    email: string | null;
+    residence_id: number | null;
+}
+
+export async function getBedroomResidents(id: number): Promise<BedroomResident[]> {
+    const res = await fetchWithAuth(`${BASE}${id}/residents/`);
+    if (!res.ok) throw new Error(`Error ${res.status}`);
+    return res.json();
 }
 
 export async function listResidents() {

--- a/frontend/src/services/bedrooms.ts
+++ b/frontend/src/services/bedrooms.ts
@@ -5,6 +5,7 @@ const BASE = '/api/bedrooms/';
 export interface BedroomResident {
     id: number;
     full_name: string;
+    email: string | null;
 }
 
 export interface Bedroom {


### PR DESCRIPTION
## Summary
- Nuevo endpoint `GET /api/bedrooms/<id>/residents/` que devuelve los residentes activos de una habitación
- Botón "Ver detalles" en cada tarjeta de habitación que abre un dialog con: número, edificio, planta, tipo, estado y lista de residentes actuales con nombre y email
- Botón "Editar Información" dentro del dialog que conecta con el modal de edición existente

## Test plan
- [x] Acceder al panel de administración → sección Habitaciones
- [x] Hacer click en "Ver detalles" de cualquier habitación — debe abrirse el dialog con los datos correctos
- [x] Verificar que una habitación libre muestra "No hay residentes asignados"
- [x] Verificar que una habitación ocupada muestra la lista de residentes con nombre y email
- [x] Hacer click en "Editar Información" — debe cerrar el dialog y abrir el modal de edición con datos precargados
- [x] `GET /api/bedrooms/<id>/residents/` devuelve 200 con la lista correcta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Chat en tiempo real: vistas de admin y estudiante para grupos y mensajes privados.
  * Gestión de pases de visita: creación, listados (activos/próximos) y página de administración de políticas.
  * Página de Paquetes con conteo no leído y QR de recogida.
  * Panel de detalles de habitación (“Ver detalles”) mostrando residentes activos.

* **Mejoras**
  * Interfaz de habitaciones: vista lista/mapa, selección, validaciones y flujo de edición unificado.
  * Notificaciones y toasts en acciones de eventos y chats.

* **Tests**
  * Cobertura nueva para el endpoint de residentes por habitación y para pases de visita.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->