### PR TITLE
fix: Ocultar campo contraseña en formulario de edición de residente

### DIFF
--- a/frontend/src/pages/Residents/components/ResidentFormDialog.tsx
+++ b/frontend/src/pages/Residents/components/ResidentFormDialog.tsx
@@ -200,23 +200,25 @@ export function ResidentFormDialog({
             )}
           </div>
 
-          {/* Password */}
-          <div className="space-y-1.5">
-            <Label htmlFor="res-password">
-              Contraseña {isEdit ? "(dejar en blanco para no cambiar)" : "(opcional — se enviará email de bienvenida si está vacía)"}
-            </Label>
-            <Input
-              id="res-password"
-              type="password"
-              placeholder={isEdit ? "Nueva contraseña" : "Contraseña temporal"}
-              value={form.password}
-              onChange={(e) => set("password", e.target.value)}
-              aria-invalid={!!errors.password}
-            />
-            {errors.password && (
-              <p className="text-xs text-red-600">{errors.password}</p>
-            )}
-          </div>
+          {/* Password — solo en creación */}
+          {!isEdit && (
+            <div className="space-y-1.5">
+              <Label htmlFor="res-password">
+                Contraseña (opcional — se enviará email de bienvenida si está vacía)
+              </Label>
+              <Input
+                id="res-password"
+                type="password"
+                placeholder="Contraseña temporal"
+                value={form.password}
+                onChange={(e) => set("password", e.target.value)}
+                aria-invalid={!!errors.password}
+              />
+              {errors.password && (
+                <p className="text-xs text-red-600">{errors.password}</p>
+              )}
+            </div>
+          )}
 
           {/* Bedroom dropdown */}
           <div className="space-y-1.5">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras**
  * El campo de contraseña ahora solo aparece al crear nuevos residentes. Durante la edición de residentes existentes, este campo no se visualiza en el formulario.
  * Se aclaró el comportamiento de contraseñas: cuando se deja en blanco al crear un residente, se enviará automáticamente un correo de bienvenida con la contraseña temporal al nuevo residente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->