### PR TITLE
fix: Restringir el campo lugar del evento [NX-FB.05]

### DIFF
--- a/backend/apps/events/migrations/0002_event_internal_external_reservations.py
+++ b/backend/apps/events/migrations/0002_event_internal_external_reservations.py
@@ -1,0 +1,79 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("spaces", "0002_commonspace_reservation_interval_minutes"),
+        ("events", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="event_type",
+            field=models.CharField(
+                choices=[("internal", "Interno"), ("external", "Externo")],
+                default="external",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="reservation",
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="event",
+                to="spaces.spacereservation",
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="space",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name="events",
+                to="spaces.commonspace",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="event",
+            name="location",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+        migrations.AddConstraint(
+            model_name="event",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(
+                        ("event_type", "internal"),
+                        ("reservation__isnull", False),
+                        ("space__isnull", False),
+                    ),
+                    ("event_type", "external"),
+                    _connector="OR",
+                ),
+                name="event_internal_requires_space_and_reservation",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="event",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    models.Q(
+                        ("event_type", "external"),
+                        ("reservation__isnull", True),
+                        ("space__isnull", True),
+                    ),
+                    ("event_type", "internal"),
+                    _connector="OR",
+                ),
+                name="event_external_forbids_space_and_reservation",
+            ),
+        ),
+    ]

--- a/backend/apps/events/models.py
+++ b/backend/apps/events/models.py
@@ -1,13 +1,37 @@
 from django.db import models
 from django.conf import settings
 from apps.residences.models import Residence
+from apps.spaces.models import CommonSpace, SpaceReservation
 
 class Event(models.Model):
+    class Type(models.TextChoices):
+        INTERNAL = "internal", "Interno"
+        EXTERNAL = "external", "Externo"
+
     title = models.CharField(max_length=200)
     description = models.TextField()
     start_time = models.DateTimeField()
     end_time = models.DateTimeField()
-    location = models.CharField(max_length=255)
+    event_type = models.CharField(
+        max_length=16,
+        choices=Type.choices,
+        default=Type.EXTERNAL,
+    )
+    location = models.CharField(max_length=255, blank=True, default="")
+    space = models.ForeignKey(
+        CommonSpace,
+        on_delete=models.PROTECT,
+        related_name="events",
+        null=True,
+        blank=True,
+    )
+    reservation = models.OneToOneField(
+        SpaceReservation,
+        on_delete=models.PROTECT,
+        related_name="event",
+        null=True,
+        blank=True,
+    )
     image_url = models.URLField(max_length=500, null=True, blank=True)
     tags = models.CharField(max_length=255, null=True, blank=True)
     max_participants = models.PositiveIntegerField(null=True, blank=True)
@@ -18,6 +42,22 @@ class Event(models.Model):
 
     class Meta:
         ordering = ['-start_time']
+        constraints = [
+            models.CheckConstraint(
+                name="event_internal_requires_space_and_reservation",
+                condition=(
+                    models.Q(event_type="internal", space__isnull=False, reservation__isnull=False)
+                    | models.Q(event_type="external")
+                ),
+            ),
+            models.CheckConstraint(
+                name="event_external_forbids_space_and_reservation",
+                condition=(
+                    models.Q(event_type="external", space__isnull=True, reservation__isnull=True)
+                    | models.Q(event_type="internal")
+                ),
+            ),
+        ]
 
     def __str__(self):
         return self.title
@@ -27,6 +67,12 @@ class Event(models.Model):
         return self.participations.count()
 
     def can_join(self):
+        if self.event_type == self.Type.INTERNAL and self.space_id:
+            effective_limit = self.space.capacity
+            if self.max_participants is not None:
+                effective_limit = min(self.max_participants, self.space.capacity)
+            return self.participants_count < effective_limit
+
         if self.max_participants is None:
             return True
         return self.participants_count < self.max_participants

--- a/backend/apps/events/views.py
+++ b/backend/apps/events/views.py
@@ -1,15 +1,201 @@
 import json
+from datetime import datetime
 from django.http import JsonResponse
 from django.views import View
 from django.utils.decorators import method_decorator
 from .models import Event, EventParticipation
 from django.shortcuts import get_object_or_404
+from django.db import transaction
 from django.db.utils import IntegrityError
 from django.contrib.auth import get_user_model
 from django.views.decorators.csrf import csrf_exempt
+from django.test import RequestFactory
 from apps.common.utils.jwt_auth import resolve_user_from_request
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
+from apps.spaces.models import CommonSpace, SpaceReservation
+from apps.spaces.views import SpaceReservationCreateView
+
+
+def _normalize_event_type(raw_event_type) -> str | None:
+    event_type = str(raw_event_type or "").strip().lower() or Event.Type.EXTERNAL
+    if event_type not in (Event.Type.INTERNAL, Event.Type.EXTERNAL):
+        return None
+    return event_type
+
+
+def _parse_and_validate_times(start_time_str: str, end_time_str: str, *, validate_future: bool):
+    if not start_time_str or not end_time_str:
+        return None, None, JsonResponse(
+            {"detail": "Se requiere fecha de inicio y fin."},
+            status=400,
+        )
+
+    start_time = parse_datetime(start_time_str)
+    end_time = parse_datetime(end_time_str)
+
+    if not start_time or not end_time:
+        return None, None, JsonResponse(
+            {"detail": "Formato de fecha/hora inválido."},
+            status=400,
+        )
+
+    if timezone.is_naive(start_time):
+        start_time = timezone.make_aware(start_time, timezone.get_current_timezone())
+    if timezone.is_naive(end_time):
+        end_time = timezone.make_aware(end_time, timezone.get_current_timezone())
+
+    if validate_future and start_time < timezone.now():
+        return None, None, JsonResponse(
+            {"detail": "La fecha de inicio no puede ser en el pasado."},
+            status=400,
+        )
+
+    if end_time <= start_time:
+        return None, None, JsonResponse(
+            {"detail": "La fecha de fin debe ser posterior a la de inicio."},
+            status=400,
+        )
+
+    return start_time, end_time, None
+
+
+def _serialize_event(event: Event, current_user):
+    is_joined = event.participations.filter(user=current_user).exists()
+    can_edit = event.host == current_user or getattr(current_user, "is_staff", False)
+    return {
+        "id": event.id,
+        "title": event.title,
+        "description": event.description,
+        "created_at": event.created_at.isoformat(),
+        "start_time": event.start_time.isoformat(),
+        "end_time": event.end_time.isoformat(),
+        "event_type": event.event_type,
+        "location": event.location,
+        "space": (
+            {
+                "id": event.space_id,
+                "name": event.space.name,
+            }
+            if event.space_id
+            else None
+        ),
+        "reservation_id": event.reservation_id,
+        "image_url": event.image_url,
+        "tags": event.tags,
+        "max_participants": event.max_participants,
+        "participants_count": event.participants_count,
+        "can_join": event.can_join(),
+        "can_edit": can_edit,
+        "is_joined": is_joined,
+        "host": {
+            "id": event.host.id,
+            "first_name": event.host.first_name,
+            "last_name": event.host.last_name,
+        },
+    }
+
+
+def _create_reservation_through_spaces_module(
+    *,
+    request,
+    residence,
+    space_id: int,
+    start_time: datetime,
+    end_time: datetime,
+):
+    payload = {
+        "start_time": start_time.isoformat(),
+        "end_time": end_time.isoformat(),
+        "notes": "Reserva generada automáticamente por evento interno.",
+    }
+
+    reservation_request = RequestFactory().post(
+        f"/api/spaces/{space_id}/reservations/",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+    reservation_request.user = request.user
+    reservation_request.residence = residence
+
+    response = SpaceReservationCreateView().post(reservation_request, space_id=space_id)
+    if response.status_code != 201:
+        try:
+            data = json.loads(response.content.decode("utf-8"))
+            detail = data.get("detail") or "No se pudo crear la reserva del evento interno."
+        except Exception:
+            detail = "No se pudo crear la reserva del evento interno."
+        return None, JsonResponse({"detail": detail}, status=response.status_code)
+
+    data = json.loads(response.content.decode("utf-8"))
+    reservation_id = data.get("id")
+    reservation = SpaceReservation.objects.select_related("space").filter(
+        id=reservation_id,
+        residence=residence,
+    ).first()
+
+    if not reservation:
+        return None, JsonResponse(
+            {"detail": "No se pudo recuperar la reserva creada para el evento."},
+            status=400,
+        )
+    return reservation, None
+
+
+def _space_has_active_overlap(*, residence, space_id: int, start_time: datetime, end_time: datetime, exclude_reservation_id: int | None = None) -> bool:
+    overlaps = SpaceReservation.objects.filter(
+        residence=residence,
+        space_id=space_id,
+        status=SpaceReservation.Status.ACTIVE,
+        start_time__lt=end_time,
+        end_time__gt=start_time,
+    )
+    if exclude_reservation_id:
+        overlaps = overlaps.exclude(id=exclude_reservation_id)
+    return overlaps.exists()
+
+
+def _parse_max_participants(raw_value):
+    if raw_value in (None, ""):
+        return None, None
+
+    try:
+        parsed = int(raw_value)
+    except (TypeError, ValueError):
+        return None, JsonResponse(
+            {"detail": "El límite de participantes debe ser un número entero positivo."},
+            status=400,
+        )
+
+    if parsed <= 0:
+        return None, JsonResponse(
+            {"detail": "El límite de participantes debe ser mayor que cero."},
+            status=400,
+        )
+
+    return parsed, None
+
+
+def _normalize_internal_event_limit(raw_value, space_capacity: int):
+    parsed_limit, parse_error = _parse_max_participants(raw_value)
+    if parse_error:
+        return None, parse_error
+
+    if parsed_limit is None:
+        return space_capacity, None
+
+    if parsed_limit > space_capacity:
+        return None, JsonResponse(
+            {
+                "detail": (
+                    "El límite de asistentes no puede superar el aforo del espacio "
+                    f"({space_capacity})."
+                )
+            },
+            status=400,
+        )
+
+    return parsed_limit, None
 
 @method_decorator(csrf_exempt, name='dispatch')
 class AuthenticatedView(View):
@@ -31,32 +217,8 @@ class EventListView(AuthenticatedView):
         if not hasattr(request, 'residence') or not request.residence:
             return JsonResponse({"detail": "No residence context."}, status=400)
             
-        events = Event.objects.filter(residence=request.residence).select_related('host')
-        data = []
-        for event in events:
-            is_joined = event.participations.filter(user=request.user).exists()
-            can_edit = event.host == request.user or getattr(request.user, 'is_staff', False)
-            data.append({
-                'id': event.id,
-                'title': event.title,
-                'description': event.description,
-                'created_at': event.created_at.isoformat(),
-                'start_time': event.start_time.isoformat(),
-                'end_time': event.end_time.isoformat(),
-                'location': event.location,
-                'image_url': event.image_url,
-                'tags': event.tags,
-                'max_participants': event.max_participants,
-                'participants_count': event.participants_count,
-                'can_join': event.can_join(),
-                'can_edit': can_edit,
-                'is_joined': is_joined,
-                'host': {
-                    'id': event.host.id,
-                    'first_name': event.host.first_name,
-                    'last_name': event.host.last_name,
-                }
-            })
+        events = Event.objects.filter(residence=request.residence).select_related('host', 'space')
+        data = [_serialize_event(event, request.user) for event in events]
         return JsonResponse(data, safe=False)
 
     def post(self, request):
@@ -66,20 +228,17 @@ class EventListView(AuthenticatedView):
         try:
             body = json.loads(request.body)
             
-            start_time_str = body.get('start_time')
-            end_time_str = body.get('end_time')
-            
-            if not start_time_str or not end_time_str:
-                return JsonResponse({"detail": "Se requiere fecha de inicio y fin."}, status=400)
-                
-            start_time = parse_datetime(start_time_str)
-            end_time = parse_datetime(end_time_str)
-            
-            if start_time and start_time < timezone.now():
-                return JsonResponse({"detail": "La fecha de inicio no puede ser en el pasado."}, status=400)
-                
-            if start_time and end_time and end_time <= start_time:
-                return JsonResponse({"detail": "La fecha de fin debe ser posterior a la de inicio."}, status=400)
+            event_type = _normalize_event_type(body.get('event_type'))
+            if not event_type:
+                return JsonResponse({"detail": "Tipo de evento inválido."}, status=400)
+
+            start_time, end_time, time_error = _parse_and_validate_times(
+                body.get('start_time'),
+                body.get('end_time'),
+                validate_future=True,
+            )
+            if time_error:
+                return time_error
 
             # Validar superposición de horarios solo para asistencia
             overlapping_participating = EventParticipation.objects.filter(
@@ -91,47 +250,96 @@ class EventListView(AuthenticatedView):
             if overlapping_participating:
                 return JsonResponse({"detail": "Ya asistes a otro evento en ese horario."}, status=400)
 
-            event = Event.objects.create(
-                title=body.get('title'),
-                description=body.get('description'),
-                start_time=body.get('start_time'),
-                end_time=body.get('end_time'),
-                location=body.get('location'),
-                image_url=body.get('image_url'),
-                tags=body.get('tags'),
-                max_participants=body.get('max_participants'),
-                residence=request.residence,
-                host=request.user
-            )
+            location = str(body.get('location') or '').strip()
+            space_id = body.get('space_id')
+
+            if event_type == Event.Type.INTERNAL:
+                if not space_id:
+                    return JsonResponse({"detail": "Debes seleccionar un espacio común para eventos internos."}, status=400)
+                if location:
+                    return JsonResponse({"detail": "Los eventos internos no deben incluir ubicación externa."}, status=400)
+            else:
+                if not location:
+                    return JsonResponse({"detail": "Debes indicar una ubicación para eventos externos."}, status=400)
+                if space_id:
+                    return JsonResponse({"detail": "Los eventos externos no pueden asociar un espacio común."}, status=400)
+
+            normalized_max_participants = None
+
+            with transaction.atomic():
+                reservation = None
+                space = None
+
+                if event_type == Event.Type.INTERNAL:
+                    space = get_object_or_404(
+                        CommonSpace,
+                        id=int(space_id),
+                        residence=request.residence,
+                        is_active=True,
+                    )
+                    normalized_max_participants, limit_error = _normalize_internal_event_limit(
+                        body.get('max_participants'),
+                        space.capacity,
+                    )
+                    if limit_error:
+                        return limit_error
+
+                    if _space_has_active_overlap(
+                        residence=request.residence,
+                        space_id=space.id,
+                        start_time=start_time,
+                        end_time=end_time,
+                    ):
+                        return JsonResponse(
+                            {"detail": "El espacio común ya está reservado en esa franja horaria."},
+                            status=400,
+                        )
+
+                    reservation, reservation_error = _create_reservation_through_spaces_module(
+                        request=request,
+                        residence=request.residence,
+                        space_id=space.id,
+                        start_time=start_time,
+                        end_time=end_time,
+                    )
+                    if reservation_error:
+                        transaction.set_rollback(True)
+                        return reservation_error
+                    space = reservation.space
+                else:
+                    normalized_max_participants, limit_error = _parse_max_participants(
+                        body.get('max_participants')
+                    )
+                    if limit_error:
+                        return limit_error
+
+                event = Event.objects.create(
+                    title=body.get('title'),
+                    description=body.get('description'),
+                    start_time=start_time,
+                    end_time=end_time,
+                    event_type=event_type,
+                    location=location if event_type == Event.Type.EXTERNAL else '',
+                    space=space,
+                    reservation=reservation,
+                    image_url=body.get('image_url'),
+                    tags=body.get('tags'),
+                    max_participants=normalized_max_participants,
+                    residence=request.residence,
+                    host=request.user
+                )
             return JsonResponse({'id': event.id, 'detail': 'Event created successfully'}, status=201)
         except Exception as e:
             return JsonResponse({"detail": str(e)}, status=400)
 
 class EventDetailView(AuthenticatedView):
     def get(self, request, event_id):
-        event = get_object_or_404(Event, id=event_id, residence=request.residence)
-        is_joined = event.participations.filter(user=request.user).exists()
-        can_edit = event.host == request.user or getattr(request.user, 'is_staff', False)
-        return JsonResponse({
-            'id': event.id,
-            'title': event.title,
-            'description': event.description,
-            'start_time': event.start_time.isoformat(),
-            'end_time': event.end_time.isoformat(),
-            'location': event.location,
-            'image_url': event.image_url,
-            'tags': event.tags,
-            'max_participants': event.max_participants,
-            'participants_count': event.participants_count,
-            'can_join': event.can_join(),
-            'can_edit': can_edit,
-            'is_joined': is_joined,
-            'host': {
-                'id': event.host.id,
-                'first_name': event.host.first_name,
-                'last_name': event.host.last_name,
-            }
-        })
+        event = get_object_or_404(
+            Event.objects.select_related('host', 'space'),
+            id=event_id,
+            residence=request.residence,
+        )
+        return JsonResponse(_serialize_event(event, request.user))
         
     def put(self, request, event_id):
         event = get_object_or_404(Event, id=event_id, residence=request.residence)
@@ -141,18 +349,18 @@ class EventDetailView(AuthenticatedView):
             
         try:
             body = json.loads(request.body)
-            
-            start_time_str = body.get('start_time')
-            end_time_str = body.get('end_time')
-            
-            if not start_time_str or not end_time_str:
-                return JsonResponse({"detail": "Se requiere fecha de inicio y fin."}, status=400)
-                
-            start_time = parse_datetime(start_time_str)
-            end_time = parse_datetime(end_time_str)
-            
-            if start_time and end_time and end_time <= start_time:
-                return JsonResponse({"detail": "La fecha de fin debe ser posterior a la de inicio."}, status=400)
+
+            event_type = _normalize_event_type(body.get('event_type', event.event_type))
+            if not event_type:
+                return JsonResponse({"detail": "Tipo de evento inválido."}, status=400)
+
+            start_time, end_time, time_error = _parse_and_validate_times(
+                body.get('start_time'),
+                body.get('end_time'),
+                validate_future=False,
+            )
+            if time_error:
+                return time_error
                 
             # Validar superposición de horarios solo si las fechas cambiaron
             if start_time != event.start_time or end_time != event.end_time:
@@ -165,17 +373,113 @@ class EventDetailView(AuthenticatedView):
                 
                 if overlapping_participating:
                     return JsonResponse({"detail": "Ya asistes a otro evento en ese horario."}, status=400)
-            
-            event.title = body.get('title', event.title)
-            event.description = body.get('description', event.description)
-            event.start_time = start_time
-            event.end_time = end_time
-            event.location = body.get('location', event.location)
-            event.image_url = body.get('image_url', event.image_url)
-            event.tags = body.get('tags', event.tags)
-            event.max_participants = body.get('max_participants', event.max_participants)
-            
-            event.save()
+
+            location = str(body.get('location', event.location) or '').strip()
+            requested_space_id = body.get('space_id')
+            normalized_max_participants = event.max_participants
+
+            with transaction.atomic():
+                previous_reservation = event.reservation
+                new_reservation = event.reservation
+                new_space = event.space
+                new_location = event.location
+
+                if event_type == Event.Type.INTERNAL:
+                    if requested_space_id is None:
+                        requested_space_id = event.space_id
+                    if not requested_space_id:
+                        return JsonResponse({"detail": "Debes seleccionar un espacio común para eventos internos."}, status=400)
+                    if location:
+                        return JsonResponse({"detail": "Los eventos internos no deben incluir ubicación externa."}, status=400)
+
+                    target_space = get_object_or_404(
+                        CommonSpace,
+                        id=int(requested_space_id),
+                        residence=request.residence,
+                        is_active=True,
+                    )
+                    normalized_max_participants, limit_error = _normalize_internal_event_limit(
+                        body.get('max_participants', event.max_participants),
+                        target_space.capacity,
+                    )
+                    if limit_error:
+                        return limit_error
+
+                    needs_new_reservation = (
+                        event.event_type != Event.Type.INTERNAL
+                        or not event.reservation_id
+                        or int(requested_space_id) != (event.space_id or 0)
+                        or start_time != event.start_time
+                        or end_time != event.end_time
+                    )
+
+                    if needs_new_reservation and event.reservation_id:
+                        event.reservation.status = SpaceReservation.Status.CANCELLED
+                        event.reservation.save(update_fields=['status', 'updated_at'])
+
+                    if needs_new_reservation:
+                        if _space_has_active_overlap(
+                            residence=request.residence,
+                            space_id=target_space.id,
+                            start_time=start_time,
+                            end_time=end_time,
+                            exclude_reservation_id=event.reservation_id,
+                        ):
+                            transaction.set_rollback(True)
+                            return JsonResponse(
+                                {"detail": "El espacio común ya está reservado en esa franja horaria."},
+                                status=400,
+                            )
+
+                        new_reservation, reservation_error = _create_reservation_through_spaces_module(
+                            request=request,
+                            residence=request.residence,
+                            space_id=target_space.id,
+                            start_time=start_time,
+                            end_time=end_time,
+                        )
+                        if reservation_error:
+                            transaction.set_rollback(True)
+                            return reservation_error
+                        new_space = new_reservation.space
+                    elif not event.reservation_id:
+                        return JsonResponse({"detail": "El evento interno debe tener una reserva asociada."}, status=400)
+
+                    new_location = ''
+                else:
+                    if not location:
+                        return JsonResponse({"detail": "Debes indicar una ubicación para eventos externos."}, status=400)
+                    if requested_space_id:
+                        return JsonResponse({"detail": "Los eventos externos no pueden asociar un espacio común."}, status=400)
+                    normalized_max_participants, limit_error = _parse_max_participants(
+                        body.get('max_participants', event.max_participants)
+                    )
+                    if limit_error:
+                        return limit_error
+                    new_space = None
+                    new_reservation = None
+                    new_location = location
+
+                event.title = body.get('title', event.title)
+                event.description = body.get('description', event.description)
+                event.start_time = start_time
+                event.end_time = end_time
+                event.event_type = event_type
+                event.location = new_location
+                event.space = new_space
+                event.reservation = new_reservation
+                event.image_url = body.get('image_url', event.image_url)
+                event.tags = body.get('tags', event.tags)
+                event.max_participants = normalized_max_participants
+                event.save()
+
+                should_remove_old_reservation = (
+                    previous_reservation
+                    and previous_reservation.id != event.reservation_id
+                )
+                if should_remove_old_reservation:
+                    previous_reservation.delete()
+
             return JsonResponse({'id': event.id, 'detail': 'Event updated successfully'}, status=200)
         except Exception as e:
             return JsonResponse({"detail": str(e)}, status=400)
@@ -186,7 +490,13 @@ class EventDetailView(AuthenticatedView):
         can_edit = event.host == request.user or getattr(request.user, 'is_staff', False)
         if not can_edit:
             return JsonResponse({"detail": "Unauthorized"}, status=403)
-        event.delete()
+
+        reservation = event.reservation
+        with transaction.atomic():
+            event.delete()
+            if reservation:
+                reservation.delete()
+
         return JsonResponse({"detail": "Event deleted"}, status=200)
 
 class EventJoinView(AuthenticatedView):

--- a/backend/apps/events/views.py
+++ b/backend/apps/events/views.py
@@ -328,6 +328,7 @@ class EventListView(AuthenticatedView):
                     residence=request.residence,
                     host=request.user
                 )
+                EventParticipation.objects.create(event=event, user=request.user)
             return JsonResponse({'id': event.id, 'detail': 'Event created successfully'}, status=201)
         except Exception as e:
             return JsonResponse({"detail": str(e)}, status=400)
@@ -377,6 +378,7 @@ class EventDetailView(AuthenticatedView):
             location = str(body.get('location', event.location) or '').strip()
             requested_space_id = body.get('space_id')
             normalized_max_participants = event.max_participants
+            max_participants_provided = 'max_participants' in body
 
             with transaction.atomic():
                 previous_reservation = event.reservation
@@ -459,6 +461,21 @@ class EventDetailView(AuthenticatedView):
                     new_space = None
                     new_reservation = None
                     new_location = location
+
+                if (
+                    max_participants_provided
+                    and normalized_max_participants is not None
+                    and normalized_max_participants < event.participants_count
+                ):
+                    return JsonResponse(
+                        {
+                            "detail": (
+                                "El límite de participantes no puede ser inferior al número "
+                                f"actual de asistentes ({event.participants_count})."
+                            )
+                        },
+                        status=400,
+                    )
 
                 event.title = body.get('title', event.title)
                 event.description = body.get('description', event.description)

--- a/frontend/src/pages/Social/Events/Events.tsx
+++ b/frontend/src/pages/Social/Events/Events.tsx
@@ -1,11 +1,42 @@
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 import { fetchWithAuth, API_URL } from "../../../utils/api";
+import { listCommonSpaces, isApiError, type CommonSpace } from "../../../services/reservations";
 import { EventForm } from "./components/EventForm";
 import { EventDetails } from "./components/EventDetails";
 import { UpcomingEvents } from "./components/UpcomingEvents";
 import { PastEvents } from "./components/PastEvents";
 import "./Events.css";
+
+type EventType = "internal" | "external";
+
+type EventFormState = {
+    name: string;
+    description: string;
+    photo: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    eventType: EventType;
+    location: string;
+    spaceId: string;
+    limit: string;
+    labels: string;
+};
+
+const EMPTY_EVENT_FORM: EventFormState = {
+    name: "",
+    description: "",
+    photo: "",
+    date: "",
+    startTime: "",
+    endTime: "",
+    eventType: "external",
+    location: "",
+    spaceId: "",
+    limit: "",
+    labels: "",
+};
 
 export function Events() {
     const [events, setEvents] = useState<any[]>([]);
@@ -18,20 +49,13 @@ export function Events() {
     const [selectedEvent, setSelectedEvent] = useState<any>(null);
     const [participants, setParticipants] = useState<any[]>([]);
 
-    const [newEvent, setNewEvent] = useState({
-        name: "",
-        description: "",
-        photo: "",
-        date: "",
-        startTime: "",
-        endTime: "",
-        location: "",
-        limit: "",
-        labels: "",
-    });
+    const [newEvent, setNewEvent] = useState<EventFormState>({ ...EMPTY_EVENT_FORM });
+    const [spaces, setSpaces] = useState<CommonSpace[]>([]);
+    const [isLoadingSpaces, setIsLoadingSpaces] = useState(false);
 
     useEffect(() => {
         fetchEvents();
+        fetchSpaces();
     }, []);
 
     const fetchEvents = async () => {
@@ -51,6 +75,26 @@ export function Events() {
             console.error("Error fetching events:", error);
         } finally {
             setLoading(false);
+        }
+    };
+
+    const fetchSpaces = async () => {
+        setIsLoadingSpaces(true);
+        try {
+            const data = await listCommonSpaces();
+            setSpaces(data.filter((space) => space.is_active));
+        } catch (error) {
+            if (isApiError(error)) {
+                if (error.status === 401 || error.status === 403) {
+                    setIsUnauthorized(true);
+                    return;
+                }
+                toast.error(error.message);
+                return;
+            }
+            toast.error("No se pudieron cargar los espacios comunes.");
+        } finally {
+            setIsLoadingSpaces(false);
         }
     };
 
@@ -133,7 +177,9 @@ export function Events() {
                     description: newEvent.description,
                     start_time: new Date(`${newEvent.date}T${newEvent.startTime}`).toISOString(),
                     end_time: new Date(`${newEvent.date}T${newEvent.endTime}`).toISOString(),
-                    location: newEvent.location,
+                    event_type: newEvent.eventType,
+                    location: newEvent.eventType === 'external' ? newEvent.location.trim() : "",
+                    space_id: newEvent.eventType === 'internal' ? Number(newEvent.spaceId) : null,
                     tags: newEvent.labels || null,
                     max_participants: newEvent.limit ? parseInt(newEvent.limit) : null,
                     image_url: newEvent.photo || null,
@@ -150,9 +196,7 @@ export function Events() {
                 setIsCreateEventOpen(false);
                 setIsEditingEvent(false);
                 setEditingEventId(null);
-                setNewEvent({
-                    name: "", description: "", photo: "", date: "", startTime: "", endTime: "", location: "", limit: "", labels: "",
-                });
+                setNewEvent({ ...EMPTY_EVENT_FORM });
                 fetchEvents();
             } else {
                 const data = await response.json();
@@ -228,9 +272,7 @@ export function Events() {
                 <button
                     className="bg-primary text-primary-foreground hover:bg-primary/90 px-5 py-2.5 rounded-lg font-medium transition-colors flex items-center gap-2 shadow-sm whitespace-nowrap"
                     onClick={() => {
-                        setNewEvent({
-                            name: "", description: "", photo: "", date: "", startTime: "", endTime: "", location: "", limit: "", labels: "",
-                        });
+                        setNewEvent({ ...EMPTY_EVENT_FORM });
                         setIsEditingEvent(false);
                         setEditingEventId(null);
                         setIsCreateEventOpen(true);
@@ -267,6 +309,8 @@ export function Events() {
                     isEditingEvent={isEditingEvent}
                     newEvent={newEvent}
                     setNewEvent={setNewEvent}
+                    spaces={spaces}
+                    isLoadingSpaces={isLoadingSpaces}
                     handleSaveEvent={handleSaveEvent}
                     setIsCreateEventOpen={setIsCreateEventOpen}
                 />
@@ -287,7 +331,9 @@ export function Events() {
                         date: event.start_time.split('T')[0],
                         startTime: new Date(event.start_time).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }),
                         endTime: new Date(event.end_time).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }),
-                        location: event.location,
+                        eventType: event.event_type || 'external',
+                        location: event.location || "",
+                        spaceId: event.space?.id ? String(event.space.id) : "",
                         limit: event.max_participants ? event.max_participants.toString() : "",
                         labels: event.tags || "",
                     });

--- a/frontend/src/pages/Social/Events/components/CommunityEvent.tsx
+++ b/frontend/src/pages/Social/Events/components/CommunityEvent.tsx
@@ -6,6 +6,7 @@ export function CommunityEvent({
     image,
     tags,
     isJoined,
+    canJoin,
     isPast,
     onJoin,
     onLeave,
@@ -13,6 +14,7 @@ export function CommunityEvent({
 }: any) {
     const displayTag = tags ? tags.split(',')[0].trim() : null;
     const isAdmin = localStorage.getItem('userRole') === 'admin';
+    const canUserJoin = typeof canJoin === 'boolean' ? canJoin : true;
 
     return (
         <div
@@ -38,7 +40,7 @@ export function CommunityEvent({
                 <div className="mt-auto pt-2 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4" onClick={(e) => e.stopPropagation()}>
                     <div className="flex items-center">
                         <span className="text-sm font-medium text-muted-foreground bg-muted px-3 py-1 rounded-full">
-                            +{attendees} {isPast ? 'fueron' : 'van'}
+                            {attendees} {"asistentes"}
                         </span>
                     </div>
                     {isPast ? (
@@ -58,6 +60,12 @@ export function CommunityEvent({
                                 title="Desapuntarme"
                             >
                                 ✕
+                            </button>
+                        </div>
+                    ) : !canUserJoin ? (
+                        <div className="w-full sm:w-auto">
+                            <button className="w-full bg-muted text-muted-foreground px-4 py-2 rounded-lg font-medium text-sm cursor-default" disabled>
+                                Aforo completado
                             </button>
                         </div>
                     ) : (

--- a/frontend/src/pages/Social/Events/components/EventDetails.tsx
+++ b/frontend/src/pages/Social/Events/components/EventDetails.tsx
@@ -22,6 +22,9 @@ export function EventDetails({
     const now = new Date();
     const isPastEvent = new Date(selectedEvent.end_time) < now;
     const isAdmin = localStorage.getItem('userRole') === 'admin';
+    const venueLabel = selectedEvent.event_type === 'internal'
+        ? `Espacio común: ${selectedEvent.space?.name || 'Sin espacio'}`
+        : `Ubicación: ${selectedEvent.location}`;
 
     return (
         <div className="dialog-overlay" onClick={() => setSelectedEvent(null)}>
@@ -36,7 +39,7 @@ export function EventDetails({
 
                     <div className="details-info-row">
                         <span>🗓️ {new Date(selectedEvent.start_time).toLocaleString('es-ES', { weekday: 'short', day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })} - {new Date(selectedEvent.end_time).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}</span>
-                        <span>📍 {selectedEvent.location}</span>
+                        <span>📍 {venueLabel}</span>
                     </div>
 
                     <div className="details-description">
@@ -89,6 +92,10 @@ export function EventDetails({
                         <p className="no-participants" style={{ width: '100%', textAlign: 'center' }}>Este evento ya ha finalizado.</p>
                     ) : isAdmin ? null : selectedEvent.is_joined ? (
                         <button className="btn-leave" style={{ width: '100%' }} onClick={async () => { await handleLeaveEvent(selectedEvent.id); setSelectedEvent(null); }}>Desapuntarme</button>
+                    ) : selectedEvent.can_join === false ? (
+                        <button className="btn-secondary" style={{ width: '100%', cursor: 'default' }} disabled>
+                            Aforo completado
+                        </button>
                     ) : (
                         <button className="btn-join" style={{ width: '100%', justifyContent: 'center' }} onClick={async () => { await handleJoinEvent(selectedEvent.id); setSelectedEvent(null); }}>Apuntarme al Evento</button>
                     )}

--- a/frontend/src/pages/Social/Events/components/EventForm.tsx
+++ b/frontend/src/pages/Social/Events/components/EventForm.tsx
@@ -1,15 +1,40 @@
 import type React from 'react';
 
+type EventType = 'internal' | 'external';
+
+type EventFormState = {
+    name: string;
+    description: string;
+    photo: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    eventType: EventType;
+    location: string;
+    spaceId: string;
+    limit: string;
+    labels: string;
+};
+
+type CommonSpaceOption = {
+    id: number;
+    name: string;
+};
+
 export function EventForm({
     isEditingEvent,
     newEvent,
     setNewEvent,
+    spaces,
+    isLoadingSpaces,
     handleSaveEvent,
     setIsCreateEventOpen,
 }: {
     isEditingEvent: boolean;
-    newEvent: any;
-    setNewEvent: React.Dispatch<React.SetStateAction<any>>;
+    newEvent: EventFormState;
+    setNewEvent: React.Dispatch<React.SetStateAction<EventFormState>>;
+    spaces: CommonSpaceOption[];
+    isLoadingSpaces: boolean;
     handleSaveEvent: (e: React.FormEvent) => void;
     setIsCreateEventOpen: (open: boolean) => void;
 }) {
@@ -113,19 +138,57 @@ export function EventForm({
                         </div>
                     </div>
                     <div className="space-y-2">
-                        <label htmlFor="location" className="text-sm font-medium leading-none">Lugar</label>
-                        <div className="relative">
-                            <span className="absolute left-3 top-2.5 text-muted-foreground text-sm">📍</span>
-                            <input
-                                id="location"
-                                className="flex h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                                placeholder="Ej: Sala Común"
-                                value={newEvent.location}
-                                onChange={(e) => setNewEvent({ ...newEvent, location: e.target.value })}
-                                required
-                            />
+                        <label className="text-sm font-medium leading-none">Tipo de evento</label>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <button
+                                type="button"
+                                className={`rounded-md border px-4 py-2 text-sm text-left transition-colors ${newEvent.eventType === 'internal' ? 'border-primary bg-primary/10 text-foreground' : 'border-input bg-background text-muted-foreground hover:text-foreground'}`}
+                                onClick={() => setNewEvent({ ...newEvent, eventType: 'internal', location: '' })}
+                            >
+                                Interno (espacio común)
+                            </button>
+                            <button
+                                type="button"
+                                className={`rounded-md border px-4 py-2 text-sm text-left transition-colors ${newEvent.eventType === 'external' ? 'border-primary bg-primary/10 text-foreground' : 'border-input bg-background text-muted-foreground hover:text-foreground'}`}
+                                onClick={() => setNewEvent({ ...newEvent, eventType: 'external', spaceId: '' })}
+                            >
+                                Externo (ubicación libre)
+                            </button>
                         </div>
                     </div>
+                    {newEvent.eventType === 'internal' ? (
+                        <div className="space-y-2">
+                            <label htmlFor="space" className="text-sm font-medium leading-none">Espacio común</label>
+                            <select
+                                id="space"
+                                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                value={newEvent.spaceId}
+                                onChange={(e) => setNewEvent({ ...newEvent, spaceId: e.target.value })}
+                                required
+                                disabled={isLoadingSpaces}
+                            >
+                                <option value="">{isLoadingSpaces ? 'Cargando espacios...' : 'Selecciona un espacio'}</option>
+                                {spaces.map((space) => (
+                                    <option key={space.id} value={space.id}>{space.name}</option>
+                                ))}
+                            </select>
+                        </div>
+                    ) : (
+                        <div className="space-y-2">
+                            <label htmlFor="location" className="text-sm font-medium leading-none">Lugar externo</label>
+                            <div className="relative">
+                                <span className="absolute left-3 top-2.5 text-muted-foreground text-sm">📍</span>
+                                <input
+                                    id="location"
+                                    className="flex h-10 w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                    placeholder="Ej: Polideportivo municipal"
+                                    value={newEvent.location}
+                                    onChange={(e) => setNewEvent({ ...newEvent, location: e.target.value })}
+                                    required
+                                />
+                            </div>
+                        </div>
+                    )}
                     <div className="space-y-2">
                         <label htmlFor="photo" className="text-sm font-medium leading-none">URL de la foto</label>
                         <div className="relative">

--- a/frontend/src/pages/Social/Events/components/UpcomingEvents.tsx
+++ b/frontend/src/pages/Social/Events/components/UpcomingEvents.tsx
@@ -36,6 +36,7 @@ export function UpcomingEvents({
                     image={event.image_url || "https://images.unsplash.com/photo-1489599849927-2ee91cede3ba?auto=format&fit=crop&q=80&w=400"}
                     tags={event.tags}
                     isJoined={event.is_joined}
+                    canJoin={event.can_join}
                     isPast={false}
                     onJoin={handleJoinEvent}
                     onLeave={handleLeaveEvent}


### PR DESCRIPTION
Actualizar la creación de eventos para integrarlo con el sistema de reservas de espacios comunes, distinguiendo así entre:

- Eventos internos (realizados en espacios comunes de la residencia)
- Eventos externos (realizados en espacios externos a la residencia)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Características**
  * Eventos ahora pueden ser internos (en espacios comunes) o externos.
  * Para internos se selecciona un espacio común y se crea/reserva automáticamente el espacio.
  * Capacidad de eventos internos se adapta a la capacidad del espacio.
  * Formulario y edición soportan tipo de evento y validaciones específicas.

* **Correcciones**
  * El botón de unirse se deshabilita cuando el aforo está completo.
  * Vista de detalles muestra “Espacio común: …” o “Ubicación: …” según tipo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->