### PR TITLE
feat: descartar notificaciones resident y correcciones bugs

### DIFF
--- a/frontend/src/components/StudentHome.tsx
+++ b/frontend/src/components/StudentHome.tsx
@@ -12,6 +12,7 @@ import {
     User,
     Users,
     Utensils,
+    X,
     Wifi
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -36,7 +37,10 @@ interface StudentHomeProps {
 }
 
 const HOME_NOTIFICATIONS_SEEN_IDS_KEY = "home-notifications-seen-ids";
+const HOME_NOTIFICATIONS_DISMISSED_IDS_KEY = "home-notifications-dismissed-ids";
 const HOME_INCIDENCES_DISMISSED_IDS_KEY = "home-incidences-dismissed-ids";
+const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
+const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
 const NOTIFICATIONS_POLL = 15000;
 const NOTIFICATIONS_LIMIT = 12;
 
@@ -93,6 +97,14 @@ const getInitialSeenIds = (): string[] => {
     return parseSeenIds(globalThis.localStorage.getItem(HOME_NOTIFICATIONS_SEEN_IDS_KEY));
 };
 
+const getInitialDismissedNotificationIds = (): string[] => {
+    if (typeof window === "undefined") {
+        return [];
+    }
+
+    return parseSeenIds(globalThis.localStorage.getItem(HOME_NOTIFICATIONS_DISMISSED_IDS_KEY));
+};
+
 const getInitialDismissedIncidenceIds = (): string[] => {
     if (typeof window === "undefined") {
         return [];
@@ -105,6 +117,34 @@ const saveStoredIds = (key: string, ids: string[]) => {
     if (typeof window !== "undefined") {
         globalThis.localStorage.setItem(key, JSON.stringify(ids));
     }
+};
+
+const getAnnouncementsSeenAtMs = (): number => {
+    if (typeof window === "undefined") {
+        return 0;
+    }
+
+    const raw = globalThis.localStorage.getItem(HOME_ANNOUNCEMENTS_SEEN_AT_KEY);
+    if (!raw) {
+        return 0;
+    }
+
+    const parsedMs = Date.parse(raw);
+    return Number.isFinite(parsedMs) ? parsedMs : 0;
+};
+
+const getIncidencesSeenAtMs = (): number => {
+    if (typeof window === "undefined") {
+        return 0;
+    }
+
+    const raw = globalThis.localStorage.getItem(HOME_INCIDENCES_SEEN_AT_KEY);
+    if (!raw) {
+        return 0;
+    }
+
+    const parsedMs = Date.parse(raw);
+    return Number.isFinite(parsedMs) ? parsedMs : 0;
 };
 
 type HomeNotification = {
@@ -173,15 +213,15 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
     const [isNotificationsLoading, setIsNotificationsLoading] = useState(false);
     const [seenNotificationIds, setSeenNotificationIds] = useState<string[]>(getInitialSeenIds);
     const [dismissedIncidenceIds, setDismissedIncidenceIds] = useState<string[]>(getInitialDismissedIncidenceIds);
-    const [unviewedAnnouncements, setUnviewedAnnouncements] = useState(0);
     const [pendingPackages, setPendingPackages] = useState<number>(0);
     const [currentUserId, setCurrentUserId] = useState<number | null>(null);
     const [isSessionUserResolved, setIsSessionUserResolved] = useState(false);
     const notificationsRequestIdRef = useRef(0);
+    const dismissedNotificationIdsRef = useRef<string[]>(getInitialDismissedNotificationIds());
 
     const wifiPassword = "NexUS2026@Residence";
     const unreadCount = notifications.filter((notification) => !seenNotificationIds.includes(notification.id)).length;
-    const hasUnreadNotifications = unreadCount > 0 || unviewedAnnouncements > 0;
+    const hasUnreadNotifications = unreadCount > 0;
 
     // --- CARGA DE DATOS REALES ---
     useEffect(() => {
@@ -241,6 +281,12 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
         });
     };
 
+    const appendDismissedNotificationIds = (notificationIds: string[]) => {
+        const nextIds = Array.from(new Set([...dismissedNotificationIdsRef.current, ...notificationIds]));
+        dismissedNotificationIdsRef.current = nextIds;
+        saveStoredIds(HOME_NOTIFICATIONS_DISMISSED_IDS_KEY, nextIds);
+    };
+
     const appendDismissedIncidenceIds = (notificationIds: string[]) => {
         setDismissedIncidenceIds((previousIds) => {
             const nextIds = Array.from(new Set([...previousIds, ...notificationIds]));
@@ -250,6 +296,8 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
     };
 
     const buildAnnouncementItems = useCallback((announcements: AnnouncementItem[]): HomeNotification[] => {
+        const announcementsSeenAtMs = getAnnouncementsSeenAtMs();
+
         return announcements
             .filter((announcement) => !announcement.has_passed)
             .map((announcement) => {
@@ -263,12 +311,16 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                     source: "announcements" as const,
                     createdAt,
                 };
-            });
+            })
+            .filter((announcement) => Date.parse(announcement.createdAt) > announcementsSeenAtMs);
     }, []);
 
     const buildIncidenceItems = useCallback((incidenceItems: IncidenceNotificationItem[]): HomeNotification[] => {
+        const incidencesSeenAtMs = getIncidencesSeenAtMs();
+
         return incidenceItems
             .filter((item) => !dismissedIncidenceIds.includes(item.id))
+            .filter((item) => Date.parse(item.created_at) > incidencesSeenAtMs)
             .map((item) => ({
                 id: item.id,
                 title: `[Incidencias] ${item.title || "Nueva incidencia"}`,
@@ -329,13 +381,11 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             // 2. Ejecución paralela de peticiones
             const [
                 announcementsRes, 
-                unviewedRes, 
                 incidencesRes, 
                 eventsRes, 
                 packagesRes
             ] = await Promise.allSettled([
                 announcementService.getAnnouncements(),
-                announcementService.getUnviewedCount(),
                 fetchWithAuth(`${API_URL_INCIDENCES}notifications/`),
                 fetchWithAuth(API_URL),
                 packagesService.getPendingCount(),
@@ -361,13 +411,10 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                 mergedNotifications.push(...buildEventItems(Array.isArray(eventsData) ? eventsData : []));
             }
 
-            // 5. Actualización de contadores
-            if (unviewedRes.status === "fulfilled") {
-                setUnviewedAnnouncements(unviewedRes.value.count);
-            }
+            const visibleNotifications = mergedNotifications.filter((notification) => !dismissedNotificationIdsRef.current.includes(notification.id));
 
-            // 6. Ordenación y Límite
-            const sorted = mergedNotifications
+            // 5. Ordenación y Límite
+            const sorted = visibleNotifications
                 .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
                 .slice(0, NOTIFICATIONS_LIMIT);
 
@@ -421,6 +468,17 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
         }
     };
 
+    const handleDismissNotification = (notification: HomeNotification) => {
+        appendSeenNotificationIds([notification.id]);
+        appendDismissedNotificationIds([notification.id]);
+
+        if (notification.source === "incidences") {
+            appendDismissedIncidenceIds([notification.id]);
+        }
+
+        setNotifications((previous) => previous.filter((item) => item.id !== notification.id));
+    };
+
     const handleCopyPassword = () => {
         const textarea = document.createElement('textarea');
         textarea.value = wifiPassword;
@@ -471,7 +529,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                         <Popover open={isNotificationsOpen} onOpenChange={handleNotificationsOpenChange}>
                             <PopoverTrigger asChild>
                                 <Button size="icon" variant="ghost" className="text-primary-foreground hover:bg-primary-foreground/20 hover:scale-110 rounded-full transition-all relative">
-                                    <Bell className="w-6 h-6" />
+                                    <Bell className="w-5 h-5" />
                                     {hasUnreadNotifications && (
                                         <span className="absolute top-1 right-1 w-2.5 h-2.5 bg-destructive rounded-full border-2 border-primary" />
                                     )}
@@ -498,6 +556,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                                                     description={notification.description}
                                                     time={notification.time}
                                                     type={notification.type}
+                                                    onDismiss={() => handleDismissNotification(notification)}
                                                     onOpenSource={() => {
                                                         if (notification.source === "incidences") {
                                                             const incidenceIds = notifications
@@ -621,6 +680,7 @@ interface NotificationCardProps {
     description: string;
     time: string;
     type: NotificationType;
+    onDismiss: () => void;
     onOpenSource: () => void;
 }
 
@@ -632,7 +692,7 @@ interface QuickActionProps {
     onClick: () => void;
 }
 
-function NotificationCard({ icon, title, description, time, type, onOpenSource }: NotificationCardProps) {
+function NotificationCard({ icon, title, description, time, type, onDismiss, onOpenSource }: NotificationCardProps) {
     const bgColors: Record<NotificationType, string> = {
         urgent: "bg-orange-50 border-orange-200",
         admin: "bg-blue-50 border-blue-200",
@@ -643,22 +703,34 @@ function NotificationCard({ icon, title, description, time, type, onOpenSource }
     };
 
     return (
-        <button
-            className={`w-full p-4 rounded-xl border ${bgColors[type] || bgColors.info} transition-colors hover:shadow-sm text-left`}
-            onClick={onOpenSource}
-            type="button"
-        >
-            <div className="flex gap-3">
-                <div className="flex-shrink-0 w-10 h-10 rounded-full bg-white flex items-center justify-center shadow-sm">
-                    {icon}
+        <div className={`relative w-full rounded-xl border ${bgColors[type] || bgColors.info} transition-colors hover:shadow-sm`}>
+            <button
+                className="w-full p-4 pr-12 text-left"
+                onClick={onOpenSource}
+                type="button"
+            >
+                <div className="flex gap-3">
+                    <div className="flex-shrink-0 w-10 h-10 rounded-full bg-white flex items-center justify-center shadow-sm">
+                        {icon}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <h4 className="font-bold text-gray-900 text-sm mb-1">{title}</h4>
+                        <p className="text-xs text-gray-600 mb-2">{description}</p>
+                        <p className="text-xs text-gray-400">{time}</p>
+                    </div>
                 </div>
-                <div className="flex-1 min-w-0">
-                    <h4 className="font-bold text-gray-900 text-sm mb-1">{title}</h4>
-                    <p className="text-xs text-gray-600 mb-2">{description}</p>
-                    <p className="text-xs text-gray-400">{time}</p>
-                </div>
-            </div>
-        </button>
+            </button>
+            <Button
+                aria-label={`Descartar notificación ${title}`}
+                className="absolute right-2 top-2 w-9 h-9 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all"
+                onClick={onDismiss}
+                size="icon"
+                type="button"
+                variant="ghost"
+            >
+                <X className="h-5 w-5" />
+            </Button>
+        </div>
     );
 }
 

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { AlertCircle, Calendar, Home, MessageSquare, User } from "lucide-react";
 import { toast } from "sonner";
@@ -18,12 +18,13 @@ import { StudentReservations } from "./StudentReservations";
 import { chatsService, type ChatRealtimeEvent } from "../services/chats";
 import { authService } from "../services/auth";
 import { ActiveGuestPassesPage } from "../pages/Visitors/ActiveGuestPasses";
+import type { ResidenceBranding } from "../services/branding";
 
 interface StudentViewProps {
     onLogout: () => void;
 }
 
-const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
+const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
 
 function buildResidentUnreadGroupsStorageKey(email: string): string | null {
     const normalized = email.trim().toLowerCase();
@@ -44,6 +45,7 @@ function persistResidentUnreadGroupIncrement(email: string, groupId: number): vo
         parsed[String(groupId)] = nextValue;
         globalThis.localStorage.setItem(storageKey, JSON.stringify(parsed));
     } catch {
+        //
     }
 }
 
@@ -75,13 +77,12 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const [hasGroupChatNews, setHasGroupChatNews] = useState(false);
     const [hasPrivateChatNews, setHasPrivateChatNews] = useState(false);
     const previousUnreadCount = useRef<number | null>(null);
-    const markAsViewedTimeoutRef = useRef<number | null>(null);
     const processedGroupMessageEventKeysRef = useRef<Set<string>>(new Set());
 
     const hasAnyChatNews = hasGroupChatNews || hasPrivateChatNews;
 
-    const isGroupLifecycleEvent = (evt: ChatRealtimeEvent): boolean =>
-        evt.event === "group_created" || evt.event === "group_updated" || evt.event === "group_deleted";
+    const isGroupLifecycleEvent = useCallback((evt: ChatRealtimeEvent): boolean =>
+        evt.event === "group_created" || evt.event === "group_updated" || evt.event === "group_deleted", []);
 
     const isIncomingMessageEvent = (evt: ChatRealtimeEvent): boolean =>
         evt.event === "group_message_created" || evt.event === "private_message_created";
@@ -112,7 +113,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const getSenderEmailFromEvent = (evt: ChatRealtimeEvent): string =>
         typeof evt.payload?.sender_email === "string" ? evt.payload.sender_email.trim().toLowerCase() : "";
 
-    const handleGroupLifecycleRealtimeEvent = (
+    const handleGroupLifecycleRealtimeEvent = useCallback((
         evt: ChatRealtimeEvent,
         isViewingGroupChats: boolean,
     ): boolean => {
@@ -127,7 +128,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
         }
 
         return true;
-    };
+    }, [isGroupLifecycleEvent]);
 
     useEffect(() => {
         let mounted = true;
@@ -160,7 +161,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
 
         const source = chatsService.subscribeToEvents((evt) => {
             if (evt.event === "branding_updated" && evt.payload) {
-                import("../hooks/useTenantBranding").then((m) => m.applyGlobalBranding(evt.payload as any));
+                import("../hooks/useTenantBranding").then((m) => m.applyGlobalBranding(evt.payload as unknown as ResidenceBranding));
                 return;
             }
 
@@ -212,7 +213,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
         return () => {
             source.close();
         };
-    }, [activeTab, communityChatSubTab, currentUserEmail, isCommunityChatActive]);
+    }, [activeTab, communityChatSubTab, currentUserEmail, handleGroupLifecycleRealtimeEvent, isCommunityChatActive]);
 
     useEffect(() => {
         if (activeTab !== "community") {
@@ -222,15 +223,24 @@ export function StudentView({ onLogout }: StudentViewProps) {
     }, [activeTab]);
 
     useEffect(() => {
+        if (activeTab === "announcements") {
+            globalThis.localStorage.setItem(HOME_ANNOUNCEMENTS_SEEN_AT_KEY, new Date().toISOString());
+        }
+
         const loadUnreadCount = async () => {
             try {
                 const data = await announcementService.getUnviewedCount();
                 const nextCount = data.count;
 
+                if (activeTab === "announcements") {
+                    previousUnreadCount.current = nextCount;
+                    setUnreadAnnouncements(nextCount);
+                    return;
+                }
+
                 if (
                     previousUnreadCount.current !== null
                     && nextCount > previousUnreadCount.current
-                    && activeTab !== "announcements"
                 ) {
                     toast.info("Tienes un nuevo aviso disponible", {
                         description: "Revisa la pestaña Avisos para verlo.",
@@ -246,44 +256,8 @@ export function StudentView({ onLogout }: StudentViewProps) {
 
         loadUnreadCount();
 
-        const intervalId = globalThis.setInterval(loadUnreadCount, 15000);
+        const intervalId = globalThis.setInterval(loadUnreadCount, activeTab === "announcements" ? 3000 : 15000);
         return () => globalThis.clearInterval(intervalId);
-    }, [activeTab]);
-
-    useEffect(() => {
-        if (activeTab === "incidences") {
-            globalThis.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, new Date().toISOString());
-        }
-
-        if (activeTab !== "announcements") {
-            if (markAsViewedTimeoutRef.current) {
-                globalThis.clearTimeout(markAsViewedTimeoutRef.current);
-                markAsViewedTimeoutRef.current = null;
-            }
-            return;
-        }
-
-        const markAsViewed = async () => {
-            try {
-                await announcementService.markAsViewed();
-                previousUnreadCount.current = 0;
-                setUnreadAnnouncements(0);
-            } catch {
-                // Ignorado: no bloquea la navegación
-            }
-        };
-
-        markAsViewedTimeoutRef.current = globalThis.setTimeout(() => {
-            markAsViewed();
-            markAsViewedTimeoutRef.current = null;
-        }, 5000);
-
-        return () => {
-            if (markAsViewedTimeoutRef.current) {
-                globalThis.clearTimeout(markAsViewedTimeoutRef.current);
-                markAsViewedTimeoutRef.current = null;
-            }
-        };
     }, [activeTab]);
 
     const handleNavigation = (tab: StudentTab) => {
@@ -334,7 +308,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                 tabContent = <MyMatchesPage />;
                 break;
             case "announcements":
-                tabContent = <StudentAnnouncements onGoToProfile={handleGoToProfile} onLogout={onLogout} />;
+                tabContent = <StudentAnnouncements onGoToProfile={handleGoToProfile} onLogout={onLogout} onAnnouncementsLoaded={() => setUnreadAnnouncements(0)} />;
                 break;
             case "packages":
                 tabContent = <PackagesPage onGoToProfile={handleGoToProfile} onLogout={onLogout} />;

--- a/frontend/src/components/announcement/NotificationBell.tsx
+++ b/frontend/src/components/announcement/NotificationBell.tsx
@@ -7,18 +7,37 @@ import announcementService from "../../services/announcement.service";
 interface NotificationBellProps {
   onMarkAsRead?: () => void;
   className?: string;
+  mode?: "notifications" | "announcements";
 }
 
 const TOAST_COOLDOWN_MS = 3500; // Tiempo para no repetir el mismo toast de notificación
+const TOAST_DURATION_MS = 2000;
 
-export function NotificationBell({ onMarkAsRead, className }: NotificationBellProps) {
+export function NotificationBell({ onMarkAsRead, className, mode = "notifications" }: NotificationBellProps) {
   const [unviewedCount, setUnviewedCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const lastEmptyToastTimeRef = useRef<number>(0);
+  const activeToastIdRef = useRef<string | number | undefined>(undefined);
   const hasNotifications = unviewedCount > 0;
+  const isAnnouncementsMode = mode === "announcements";
+
+  const title = isAnnouncementsMode ? "Avisos" : "Notificaciones";
+  const emptyDescription = isAnnouncementsMode
+    ? "No tienes avisos nuevos"
+    : "No tienes notificaciones nuevas";
+  const singularLabel = isAnnouncementsMode ? "aviso" : "notificación";
 
   useEffect(() => {
     loadUnviewedCount();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (activeToastIdRef.current !== undefined) {
+        toast.dismiss(activeToastIdRef.current);
+        activeToastIdRef.current = undefined;
+      }
+    };
   }, []);
 
   const loadUnviewedCount = async () => {
@@ -40,9 +59,12 @@ export function NotificationBell({ onMarkAsRead, className }: NotificationBellPr
         const now = Date.now();
         // Solo mostrar el toast de "no hay avisos" si ha pasado el cooldown
         if (now - lastEmptyToastTimeRef.current > TOAST_COOLDOWN_MS) {
-          toast.info("Avisos", {
-            description: "No tienes avisos nuevos",
-            duration: 3000,
+          if (activeToastIdRef.current !== undefined) {
+            toast.dismiss(activeToastIdRef.current);
+          }
+          activeToastIdRef.current = toast.info(title, {
+            description: emptyDescription,
+            duration: TOAST_DURATION_MS,
           });
           lastEmptyToastTimeRef.current = now;
         }
@@ -50,9 +72,12 @@ export function NotificationBell({ onMarkAsRead, className }: NotificationBellPr
         // Si hay avisos, resetear el cooldown para permitir mostrar de nuevo
         lastEmptyToastTimeRef.current = 0;
         const pluralSuffix = data.count !== 1 ? "s" : "";
-        toast.info("Avisos", {
-          description: `Tienes ${data.count} aviso${pluralSuffix} nuevo${pluralSuffix}`,
-          duration: 3000,
+        if (activeToastIdRef.current !== undefined) {
+          toast.dismiss(activeToastIdRef.current);
+        }
+        activeToastIdRef.current = toast.info(title, {
+          description: `Tienes ${data.count} ${singularLabel}${pluralSuffix} nueva${pluralSuffix}`,
+          duration: TOAST_DURATION_MS,
         });
 
         await announcementService.markAsViewed();
@@ -62,9 +87,12 @@ export function NotificationBell({ onMarkAsRead, className }: NotificationBellPr
       onMarkAsRead?.();
     } catch (error) {
       console.error("Error loading unviewed count:", error);
-      toast.error("Avisos", {
+      if (activeToastIdRef.current !== undefined) {
+        toast.dismiss(activeToastIdRef.current);
+      }
+      activeToastIdRef.current = toast.error(title, {
         description: "No se pudo cargar el estado de notificaciones.",
-        duration: 3000,
+        duration: TOAST_DURATION_MS,
       });
     } finally {
       setLoading(false);
@@ -74,12 +102,12 @@ export function NotificationBell({ onMarkAsRead, className }: NotificationBellPr
   return (
     <button
       type="button"
-      aria-label="Ver notificaciones de avisos"
+      aria-label={isAnnouncementsMode ? "Ver notificaciones de avisos" : "Ver notificaciones"}
       onClick={handleBellClick}
       disabled={loading}
       className={cn("relative h-9 w-9 inline-flex items-center justify-center rounded-full text-primary-foreground transition-colors hover:bg-primary-foreground/20", className)}
     >
-      <Bell className="w-5 h-5 text-current" />
+      <Bell className="w-4 h-4 text-current" />
       {hasNotifications && (
         <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background" />
       )}

--- a/frontend/src/pages/Incidences/components/StudentIncidences.tsx
+++ b/frontend/src/pages/Incidences/components/StudentIncidences.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback } from "react";
-import { Plus, Bell, MapPin, User, Wrench, MessageSquare, Loader2, Clock, Pencil, Trash2, LogOut } from "lucide-react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Plus, Bell, MapPin, User, Wrench, MessageSquare, Loader2, Clock, Pencil, Trash2, LogOut, X } from "lucide-react";
 import { Button } from "../../../components/ui/button";
 import { Card, CardContent } from "../../../components/ui/card";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "../../../components/ui/dialog";
@@ -21,16 +21,53 @@ interface StudentIncidencesProps {
   onLogout?: () => void;
 }
 
+type IncidenceNotification = {
+  id: string;
+  kind?: string;
+  incidence_id?: number;
+  title: string;
+  message: string;
+  created_at: string;
+};
+
+const INCIDENCE_NOTIFICATIONS_DISMISSED_KEY = "incidences-notifications-dismissed-ids";
+const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
+const LIVE_REFRESH_MS = 3000;
+
+const getDismissedNotificationIds = (): string[] => {
+  if (typeof window === "undefined") return [];
+  const raw = window.localStorage.getItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const saveDismissedNotificationIds = (ids: string[]) => {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY, JSON.stringify(ids));
+};
+
+const saveHomeIncidencesSeenAt = (timestamp?: string) => {
+  if (typeof window === "undefined" || !timestamp) return;
+  window.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
+};
+
 export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIncidencesProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [incidences, setIncidences] = useState<BaseIncidence[]>([]);
   const [selectedDetails, setSelectedDetails] = useState<BaseIncidence | null>(null);
   const [isNotesOpen, setIsNotesOpen] = useState(false);
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
-  const [notifications, setNotifications] = useState<any[]>([]);
+  const [notifications, setNotifications] = useState<IncidenceNotification[]>([]);
   const [notificationsLoading, setNotificationsLoading] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const [loading, setLoading] = useState(true);
+  const dismissedNotificationIdsRef = useRef<string[]>(getDismissedNotificationIds());
 
   const [incidenceToDelete, setIncidenceToDelete] = useState<BaseIncidence | null>(null);
   const [incidenceToEdit, setIncidenceToEdit] = useState<BaseIncidence | null>(null);
@@ -41,38 +78,54 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
   const [filterPriority, setFilterPriority] = useState('all');
   const [showOnlyMine, setShowOnlyMine] = useState(false);
 
+  const appendDismissedNotificationIds = useCallback((ids: string[]) => {
+    if (ids.length === 0) return;
+
+    const next = Array.from(new Set([...dismissedNotificationIdsRef.current, ...ids]));
+    dismissedNotificationIdsRef.current = next;
+    saveDismissedNotificationIds(next);
+  }, []);
+
   const loadNotifications = useCallback(async (markAsRead = false, silent = false) => {
     try {
       if (!silent) setNotificationsLoading(true);
       const res = await fetchWithAuth(`${API_URL_INCIDENCES}notifications/`);
       if (!res.ok) return;
       const data = await res.json();
-      const all = Array.isArray(data.results) ? data.results : [];
+      const all = Array.isArray(data.results) ? (data.results as IncidenceNotification[]) : [];
+      if (all.length > 0) {
+        saveHomeIncidencesSeenAt(all[0].created_at);
+      }
+      const latestNotifications = all.filter((n) => !dismissedNotificationIdsRef.current.includes(n.id));
       const lastReadAt = getLastReadNotificationsAt();
 
-      if (markAsRead && all.length > 0) {
-        saveLastReadNotificationsAt(all[0].created_at);
+      if (markAsRead && latestNotifications.length > 0) {
+        saveLastReadNotificationsAt(latestNotifications[0].created_at);
         setUnreadNotifications(0);
       } else {
-        const count = all.filter((n: any) => Date.parse(n.created_at) > lastReadAt).length;
+        const count = latestNotifications.filter((n) => Date.parse(n.created_at) > lastReadAt).length;
         setUnreadNotifications(count);
       }
-      setNotifications(all);
+      setNotifications(latestNotifications);
     } catch (e) { console.error(e); } finally { if (!silent) setNotificationsLoading(false); }
   }, []);
 
-  const loadIncidences = useCallback(async () => {
+  const loadIncidences = useCallback(async (silent = false) => {
     try {
-      setLoading(true);
+      if (!silent) setLoading(true);
       const res = await fetchWithAuth(API_URL_INCIDENCES);
       if (res.ok) setIncidences(await res.json());
-    } catch (e) { console.error(e); } finally { setLoading(false); }
+    } catch (e) { console.error(e); } finally { if (!silent) setLoading(false); }
   }, []);
 
   useEffect(() => {
     loadIncidences(); loadNotifications();
-    const interval = setInterval(() => loadNotifications(false, true), 15000);
-    return () => clearInterval(interval);
+    const notificationsInterval = setInterval(() => loadNotifications(false, true), LIVE_REFRESH_MS);
+    const incidencesInterval = setInterval(() => loadIncidences(true), LIVE_REFRESH_MS);
+    return () => {
+      clearInterval(notificationsInterval);
+      clearInterval(incidencesInterval);
+    };
   }, [loadIncidences, loadNotifications]);
 
   const handleDelete = async () => {
@@ -106,26 +159,48 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
         <div className="flex items-center gap-2">
           <Popover open={isNotificationsOpen} onOpenChange={(open) => { setIsNotificationsOpen(open); if (open) loadNotifications(true); }}>
             <PopoverTrigger asChild>
-              <Button type="button" size="icon" variant="ghost" className={UI_CLASSES.topIconButton} aria-label="Notificaciones">
+              <Button type="button" size="icon" variant="ghost" className={`${UI_CLASSES.topIconButton} hover:scale-100`} aria-label="Notificaciones">
                 <Bell className="w-5 h-5" />
                 {unreadNotifications > 0 && <span className={UI_CLASSES.bellBadge}>{unreadNotifications}</span>}
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-80 p-0 rounded-[28px] overflow-hidden border-none shadow-2xl">
-              <div className="bg-white p-4 border-b flex items-center justify-between">
-                <p className="text-xs font-bold uppercase tracking-[#0.2em] text-[#1B4D1C]">Notificaciones</p>
-                {notificationsLoading && <Loader2 className="w-3 h-3 animate-spin text-[#82D14C]" />}
-              </div>
-              <div className="max-h-80 overflow-y-auto p-2 bg-white">
-                {notifications.length > 0 ? notifications.map((n) => (
-                  <div key={n.id} className="p-3 mb-1 rounded-2xl bg-slate-50 border border-slate-100">
-                    <div className="flex justify-between items-start mb-1 text-left">
-                      <p className="text-xs font-bold text-slate-800">{n.title}</p>
-                      <span className="text-[9px] text-slate-400">{formatNotificationTime(n.created_at)}</span>
-                    </div>
-                    <p className="text-xs text-slate-600 mt-1 text-left">{n.message}</p>
+            <PopoverContent align="end" sideOffset={10} avoidCollisions={false} className="w-[min(26rem,calc(100vw-2rem))] p-0">
+              <div className="max-h-[70vh] overflow-y-auto rounded-md bg-white p-4">
+                <div className="mb-3 flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Bell className="h-5 w-5 text-primary" />
+                    <h3 className="font-semibold text-gray-900">Notificaciones</h3>
                   </div>
-                )) : <p className="text-center py-6 text-xs text-slate-400">Sin notificaciones</p>}
+                  {notificationsLoading && <Loader2 className="h-4 w-4 animate-spin text-primary" />}
+                </div>
+
+                <div className="space-y-3">
+                  {notifications.length > 0 ? notifications.map((n) => (
+                    <div key={n.id} className="relative rounded-xl border border-red-200 bg-red-50 p-3">
+                      <button
+                        type="button"
+                        aria-label="Descartar notificación"
+                        className="absolute right-2 top-2 h-8 w-8 rounded-lg text-slate-400 transition-all hover:bg-red-50 hover:text-red-600"
+                        onClick={() => {
+                          appendDismissedNotificationIds([n.id]);
+                          setNotifications((prev) => {
+                            const next = prev.filter((item) => item.id !== n.id);
+                            const lastReadAt = getLastReadNotificationsAt();
+                            setUnreadNotifications(next.filter((item) => Date.parse(item.created_at) > lastReadAt).length);
+                            return next;
+                          });
+                        }}
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                      <div className="mb-1 flex items-start justify-between gap-2 pr-9 text-left">
+                        <p className="text-sm font-semibold text-gray-900">{n.title}</p>
+                        <span className="text-[11px] text-gray-400">{formatNotificationTime(n.created_at)}</span>
+                      </div>
+                      <p className="text-xs text-gray-600 text-left">{n.message}</p>
+                    </div>
+                  )) : <p className="py-4 text-sm text-gray-500 text-center">Sin notificaciones</p>}
+                </div>
               </div>
             </PopoverContent>
           </Popover>
@@ -269,7 +344,7 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
                 <section className="pt-2">
                   <p className="text-[10px] font-bold uppercase text-[#3A7A1C] tracking-widest mb-4 text-left">Gestión y Actualizaciones</p>
                   <div className="relative ml-2 space-y-6 border-l-2 border-slate-100 pl-8">
-                    {selectedDetails.updates?.map((u: any) => (
+                    {selectedDetails.updates?.map((u) => (
                       <div key={u.id} className="relative">
                         <div className="absolute -left-[41px] top-1.5 h-4 w-4 rounded-full border-4 border-white bg-slate-200" />
                         <div className="bg-[#eef8ee] p-4 rounded-[22px] text-left">

--- a/frontend/src/pages/announcements/StudentAnnouncements.tsx
+++ b/frontend/src/pages/announcements/StudentAnnouncements.tsx
@@ -11,29 +11,43 @@ import { AnnouncementList } from "../../types/announcement.types";
 interface StudentAnnouncementsProps {
   onGoToProfile?: () => void;
   onLogout?: () => void;
+  onAnnouncementsLoaded?: () => void;
 }
 
-export function StudentAnnouncements({ onGoToProfile, onLogout }: StudentAnnouncementsProps) {
+export function StudentAnnouncements({ onGoToProfile, onLogout, onAnnouncementsLoaded }: StudentAnnouncementsProps) {
   const [announcements, setAnnouncements] = useState<AnnouncementList[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    loadAnnouncements();
+    loadAnnouncements(true);
+
+    const intervalId = globalThis.setInterval(() => {
+      loadAnnouncements(false);
+    }, 3000);
+
+    return () => globalThis.clearInterval(intervalId);
   }, [selectedCategory]);
 
-  const loadAnnouncements = async () => {
-    setLoading(true);
+  const loadAnnouncements = async (isInitialLoad = false) => {
+    if (isInitialLoad) {
+      setLoading(true);
+    }
+
     setError(null);
     try {
       const data = await announcementService.getAnnouncementsByCategory(selectedCategory);
       setAnnouncements(data);
+      await announcementService.markAsViewed();
+      onAnnouncementsLoaded?.();
     } catch (err) {
       setError("Error al cargar los avisos");
       console.error(err);
     } finally {
-      setLoading(false);
+      if (isInitialLoad) {
+        setLoading(false);
+      }
     }
   };
 
@@ -44,7 +58,7 @@ export function StudentAnnouncements({ onGoToProfile, onLogout }: StudentAnnounc
       <header className="bg-primary  p-6 pt-12 flex justify-between items-center shrink-0 shadow-lg sticky top-0 z-20">
         <h1 className="text-primary-foreground text-2xl font-bold">Avisos</h1>
         <div className="flex items-center gap-2">
-          <NotificationBell onMarkAsRead={loadAnnouncements} />
+          <NotificationBell mode="announcements" onMarkAsRead={loadAnnouncements} />
           <Button
             size="icon"
             variant="ghost"


### PR DESCRIPTION
Comprobar que se pueden descartar las notificaciones con la X desde la vista residente y que las notificaciones del resto de módulos funcionan con lógica, por ejemplo, si estás dentro del módulo Incidencias y se ha cambiado el estado de tu incidencia, se actualiza pero cuando vas al Panel Central no debería saltar como notificación, ya que ya ha sido vista....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la Versión

* **Nuevas Características**
  * Botón "descartar" (X) por notificación/aviso y modo específico para el indicador (notificaciones | anuncios).
  * Persistencia local de notificaciones descartadas y marcas de “visto”.

* **Mejoras de Rendimiento**
  * Polling de anuncios e incidencias más frecuente (3s) y sincronización en tiempo real mejorada.
  * Cálculo simplificado y más preciso del contador de no leídos.

* **UX**
  * Ajustes de interacción: marcado inmediato como visto al abrir anuncios, reducción del tamaño del icono de campana y manejo único de toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->