### PR TITLE
fix: prevent interaction with past events, restrict admin participation, and update chat/edit UI permissions

### DIFF
--- a/backend/apps/events/tests.py
+++ b/backend/apps/events/tests.py
@@ -597,6 +597,33 @@ class EventListViewTests(ViewTestsBase):
         )
         res = EventListView.as_view()(req)
         self.assertEqual(res.status_code, 400)
+    def test_post_create_admin_no_participation(self):
+        from apps.events.views import EventListView
+        from apps.events.models import EventParticipation
+
+        payload = {
+            "title": "Admin Created",
+            "description": "desc",
+            "event_type": "external",
+            "start_time": (self.now + timedelta(hours=3)).isoformat(),
+            "end_time": (self.now + timedelta(hours=4)).isoformat(),
+            "location": "Office",
+        }
+        # staff_user is an admin (is_staff=True)
+        req = self.setup_request(self.rf.post("/", data=json.dumps(payload), content_type="application/json"), user=self.staff_user)
+        res = EventListView.as_view()(req)
+        self.assertEqual(res.status_code, 201)
+        data = json.loads(res.content)
+        
+        # Verify no participation was created for the admin
+        self.assertEqual(EventParticipation.objects.filter(event_id=data["id"], user=self.staff_user).count(), 0)
+
+    def test_post_create_student_is_joined(self):
+        # If we ever allow students to create events, they SHOULD be joined
+        # But for now, they might fail permission. Let's mocks it or check logic.
+        # Currently is_events_admin is what blocks.
+        pass
+
 
     def test_post_internal_limit_error(self):
         from apps.events.views import EventListView
@@ -801,6 +828,44 @@ class EventDetailViewTests(ViewTestsBase):
         req = self.setup_request(self.rf.delete("/"))
         res = EventDetailView.as_view()(req, event_id=self.event_ext.id)
         self.assertEqual(res.status_code, 403)
+
+    def test_put_past_event(self):
+        from apps.events.views import EventDetailView
+
+        past_event = Event.objects.create(
+            title="Past Event",
+            start_time=self.now - timedelta(hours=2),
+            end_time=self.now - timedelta(hours=1),
+            event_type=Event.Type.EXTERNAL,
+            residence=self.residence,
+            host=self.host_user,
+            location="Somewhere",
+        )
+        payload = {"title": "New Title"}
+        req = self.setup_request(
+            self.rf.put("/", data=json.dumps(payload), content_type="application/json"),
+            user=self.host_user,
+        )
+        res = EventDetailView.as_view()(req, event_id=past_event.id)
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("ha finalizado", json.loads(res.content).get("detail", ""))
+
+    def test_delete_past_event_success(self):
+        from apps.events.views import EventDetailView
+
+        past_event = Event.objects.create(
+            title="Past Event to Delete",
+            start_time=self.now - timedelta(hours=2),
+            end_time=self.now - timedelta(hours=1),
+            event_type=Event.Type.EXTERNAL,
+            residence=self.residence,
+            host=self.host_user,
+            location="Somewhere",
+        )
+        req = self.setup_request(self.rf.delete("/"), user=self.host_user)
+        res = EventDetailView.as_view()(req, event_id=past_event.id)
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(Event.objects.filter(id=past_event.id).exists())
 
     def test_delete_success(self):
         from apps.events.views import EventDetailView
@@ -1158,6 +1223,41 @@ class EventJoinLeaveParticipantsViewTests(ViewTestsBase):
         res2 = EventLeaveView.as_view()(req, event_id=self.event.id)
         self.assertEqual(res2.status_code, 400)
 
+    def test_join_past_event(self):
+        from apps.events.views import EventJoinView
+
+        past_event = Event.objects.create(
+            title="Past Event",
+            start_time=self.now - timedelta(hours=2),
+            end_time=self.now - timedelta(hours=1),
+            event_type=Event.Type.EXTERNAL,
+            residence=self.residence,
+            host=self.host_user,
+            location="Somewhere",
+        )
+        req = self.setup_request(self.rf.post("/"))
+        res = EventJoinView.as_view()(req, event_id=past_event.id)
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("ha finalizado", json.loads(res.content).get("detail", ""))
+
+    def test_leave_past_event(self):
+        from apps.events.views import EventLeaveView
+
+        past_event = Event.objects.create(
+            title="Past Event",
+            start_time=self.now - timedelta(hours=2),
+            end_time=self.now - timedelta(hours=1),
+            event_type=Event.Type.EXTERNAL,
+            residence=self.residence,
+            host=self.host_user,
+            location="Somewhere",
+        )
+        EventParticipation.objects.create(event=past_event, user=self.user)
+        req = self.setup_request(self.rf.post("/"))
+        res = EventLeaveView.as_view()(req, event_id=past_event.id)
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("ha finalizado", json.loads(res.content).get("detail", ""))
+
     def test_participants(self):
         from apps.events.views import EventParticipantsView
 
@@ -1452,6 +1552,30 @@ class EventJoinChatViewTests(ViewTestsBase):
         self.assertEqual(res3.status_code, 201)
         member.refresh_from_db()
         self.assertTrue(member.can_interact)
+
+    def test_join_chat_admin_success(self):
+        from apps.events.views import EventJoinChatView
+        from apps.events.models import EventParticipation
+        from apps.membership.models import Membership
+        
+        # Staff needs a membership to join a chat group
+        from apps.membership.models import Role
+        admin_role, _ = Role.objects.get_or_create(name="Admin", residence=self.residence)
+        Membership.objects.create(
+            user=self.staff_user,
+            residence=self.residence,
+            role=admin_role,
+            is_active=True
+        )
+        
+        # Admin is NOT a participant
+        self.assertEqual(EventParticipation.objects.filter(event=self.event, user=self.staff_user).count(), 0)
+        
+        req = self.setup_request(self.rf.post("/"), user=self.staff_user)
+        res = EventJoinChatView.as_view()(req, event_id=self.event.id)
+        
+        # Admin should be able to join chat even without participation
+        self.assertEqual(res.status_code, 201)
 
 class MoreEventViewTests(ViewTestsBase):
     def test_leave_event_cleans_chat_member(self):

--- a/backend/apps/events/views.py
+++ b/backend/apps/events/views.py
@@ -535,7 +535,8 @@ class EventListView(AuthenticatedView):
                     event.save(update_fields=["chat_group"])
                     _publish_group_created_for_event(request, chat_group)
 
-                EventParticipation.objects.create(event=event, user=request.user)
+                if not is_events_admin(request.user, request.residence):
+                    EventParticipation.objects.create(event=event, user=request.user)
 
             return JsonResponse(
                 {"id": event.id, "detail": "Event created successfully"}, status=201
@@ -565,6 +566,12 @@ class EventDetailView(AuthenticatedView):
 
         try:
             body = json.loads(request.body)
+
+            if event.end_time < timezone.now():
+                return JsonResponse(
+                    {"detail": "No se puede editar un evento que ya ha finalizado."},
+                    status=400,
+                )
 
             event_type = _normalize_event_type(body.get("event_type", event.event_type))
             if not event_type:
@@ -812,6 +819,12 @@ class EventJoinView(AuthenticatedView):
 
         event = get_object_or_404(Event, id=event_id, residence=request.residence)
 
+        if event.end_time < timezone.now():
+            return JsonResponse(
+                {"detail": "No puedes inscribirte en un evento que ya ha finalizado."},
+                status=400,
+            )
+
         if not event.can_join():
             return JsonResponse(
                 {"detail": "El evento ha alcanzado el límite de participantes."},
@@ -862,7 +875,8 @@ class EventJoinChatView(AuthenticatedView):
         is_participant = EventParticipation.objects.filter(
             event=event, user=request.user
         ).exists()
-        if not is_participant:
+        is_admin = is_events_admin(request.user, request.residence)
+        if not is_participant and not is_admin:
             return JsonResponse(
                 {"detail": "Debes estar apuntado al evento para unirte al chat."},
                 status=403,
@@ -900,6 +914,12 @@ class EventJoinChatView(AuthenticatedView):
 class EventLeaveView(AuthenticatedView):
     def post(self, request, event_id):
         event = get_object_or_404(Event, id=event_id, residence=request.residence)
+
+        if event.end_time < timezone.now():
+            return JsonResponse(
+                {"detail": "No puedes abandonar un evento que ya ha finalizado."},
+                status=400,
+            )
 
         try:
             with transaction.atomic():

--- a/frontend/src/pages/Social/Events/components/CommunityEvent.tsx
+++ b/frontend/src/pages/Social/Events/components/CommunityEvent.tsx
@@ -23,8 +23,8 @@ export function CommunityEvent({
     const canUserJoin = typeof canJoin === 'boolean' ? canJoin : true;
     const isHost = Number(localStorage.getItem('currentUserId')) === Number(host?.id);
     const hasChat = Boolean(chatGroup?.id);
-    const canOpenChat = !isPast && hasChat && (isHost || isChatMember);
-    const canManuallyJoinChat = !isPast && hasChat && isJoined && !isChatMember;
+    const canOpenChat = !isPast && hasChat && (isHost || isChatMember) && !isAdmin;
+    const canManuallyJoinChat = !isPast && hasChat && isJoined && !isChatMember && !isAdmin;
 
     return (
         <div

--- a/frontend/src/pages/Social/Events/components/EventDetails.tsx
+++ b/frontend/src/pages/Social/Events/components/EventDetails.tsx
@@ -66,14 +66,16 @@ export function EventDetails({
                 <div className="dialog-footer" style={{ padding: '0 24px 24px 24px', margin: 0, flexDirection: 'column', gap: '8px' }}>
                     {selectedEvent.can_edit && (
                         <div style={{ display: 'flex', gap: '8px', width: '100%' }}>
-                            <button
-                                type="button"
-                                className="btn-secondary"
-                                style={{ flex: 1 }}
-                                onClick={() => onEditEvent(selectedEvent)}
-                            >
-                                Editar
-                            </button>
+                            {!isPastEvent && (
+                                <button
+                                    type="button"
+                                    className="btn-secondary"
+                                    style={{ flex: 1 }}
+                                    onClick={() => onEditEvent(selectedEvent)}
+                                >
+                                    Editar
+                                </button>
+                            )}
                             <button
                                 type="button"
                                 className="btn-secondary"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correcciones de errores**
  * Los eventos pasados no pueden ser editados ni abandonados; se devuelve un error de validación
  * Se impide que los usuarios se unan a eventos que ya han finalizado
  * Los administradores de eventos ahora pueden acceder al chat del evento sin ser participantes
  * El botón "Editar" en los detalles del evento solo se muestra cuando el evento aún está activo

<!-- end of auto-generated comment: release notes by coderabbit.ai -->