### PR TITLE
feat: notificaciones y avisos de horas limite de visitas

### DIFF
--- a/frontend/e2e/guests.spec.ts
+++ b/frontend/e2e/guests.spec.ts
@@ -38,7 +38,7 @@ test.describe('Visitantes — pases de invitado', () => {
 
   test('muestra mensaje cuando la búsqueda no tiene resultados', async ({ page }) => {
     await page.getByPlaceholder(/Buscar/i).fill('xyz-inexistente')
-    await expect(page.getByText('No hay pases que coincidan.')).toBeVisible()
+    await expect(page.getByText('No se han encontrado pases que coincidan')).toBeVisible()
   })
 
   // ── S2.40: Detalle ────────────────────────────────────────────────────────

--- a/frontend/src/components/StudentHome.tsx
+++ b/frontend/src/components/StudentHome.tsx
@@ -41,7 +41,7 @@ const HOME_NOTIFICATIONS_DISMISSED_IDS_KEY = "home-notifications-dismissed-ids";
 const HOME_INCIDENCES_DISMISSED_IDS_KEY = "home-incidences-dismissed-ids";
 const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
 const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
-const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_KEY_BASE = "visit-urgent-shared-notifications";
 const NOTIFICATIONS_POLL = 15000;
 const NOTIFICATIONS_LIMIT = 12;
 
@@ -157,12 +157,20 @@ const getIncidencesSeenAtMs = (): number => {
     return Number.isFinite(parsedMs) ? parsedMs : 0;
 };
 
-const getActiveVisitUrgentNotifications = (): VisitUrgentSharedNotification[] => {
-    if (typeof window === "undefined") {
+const buildVisitUrgentNotificationStorageKey = (email: string): string | null => {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) {
+        return null;
+    }
+    return `${VISIT_URGENT_NOTIFICATION_KEY_BASE}:${normalized}`;
+};
+
+const getActiveVisitUrgentNotifications = (storageKey: string | null): VisitUrgentSharedNotification[] => {
+    if (typeof window === "undefined" || !storageKey) {
         return [];
     }
 
-    const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+    const raw = globalThis.localStorage.getItem(storageKey);
     if (!raw) {
         return [];
     }
@@ -179,15 +187,15 @@ const getActiveVisitUrgentNotifications = (): VisitUrgentSharedNotification[] =>
 
         if (active.length !== items.length) {
             if (active.length === 0) {
-                globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+                globalThis.localStorage.removeItem(storageKey);
             } else {
-                globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+                globalThis.localStorage.setItem(storageKey, JSON.stringify(active));
             }
         }
 
         return active.sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at));
     } catch {
-        globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+        globalThis.localStorage.removeItem(storageKey);
         return [];
     }
 };
@@ -260,6 +268,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
     const [dismissedIncidenceIds, setDismissedIncidenceIds] = useState<string[]>(getInitialDismissedIncidenceIds);
     const [pendingPackages, setPendingPackages] = useState<number>(0);
     const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+    const [currentUserEmail, setCurrentUserEmail] = useState("");
     const [isSessionUserResolved, setIsSessionUserResolved] = useState(false);
     const notificationsRequestIdRef = useRef(0);
     const dismissedNotificationIdsRef = useRef<string[]>(getInitialDismissedNotificationIds());
@@ -274,6 +283,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             try {
                 const session = await authService.me();
                 setCurrentUserId(parseUserId(session.user?.id));
+                setCurrentUserEmail((session.user?.email || "").trim().toLowerCase());
                 if (session.user) {
                     // Usar el nombre real si está disponible
                     const firstName = session.user.first_name?.trim() || '';
@@ -309,6 +319,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             } catch (error) {
                 console.error("Error cargando perfil del estudiante", error);
                 setCurrentUserId(null);
+                setCurrentUserEmail("");
                 setUserData(prev => ({ ...prev, name: "Estudiante", room: "Error de conexión" }));
             } finally {
                 setIsSessionUserResolved(true);
@@ -417,7 +428,8 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
     }, []);
 
     const buildVisitUrgentItems = useCallback((): HomeNotification[] => {
-        const items = getActiveVisitUrgentNotifications();
+        const storageKey = buildVisitUrgentNotificationStorageKey(currentUserEmail);
+        const items = getActiveVisitUrgentNotifications(storageKey);
         return items.map((item) => ({
             id: item.id,
             title: item.title,
@@ -427,7 +439,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             source: "visitors" as const,
             createdAt: item.created_at,
         }));
-    }, []);
+    }, [currentUserEmail]);
 
     const loadHomeNotifications = useCallback(async (silent = false) => {
         const requestId = ++notificationsRequestIdRef.current;

--- a/frontend/src/components/StudentHome.tsx
+++ b/frontend/src/components/StudentHome.tsx
@@ -41,8 +41,18 @@ const HOME_NOTIFICATIONS_DISMISSED_IDS_KEY = "home-notifications-dismissed-ids";
 const HOME_INCIDENCES_DISMISSED_IDS_KEY = "home-incidences-dismissed-ids";
 const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
 const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
+const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
 const NOTIFICATIONS_POLL = 15000;
 const NOTIFICATIONS_LIMIT = 12;
+
+type VisitUrgentSharedNotification = {
+    id: string;
+    title: string;
+    message: string;
+    created_at: string;
+    expires_at: string;
+    source: "visitors";
+};
 
 const parseSeenIds = (raw: string | null): string[] => {
     if (!raw) {
@@ -145,6 +155,41 @@ const getIncidencesSeenAtMs = (): number => {
 
     const parsedMs = Date.parse(raw);
     return Number.isFinite(parsedMs) ? parsedMs : 0;
+};
+
+const getActiveVisitUrgentNotifications = (): VisitUrgentSharedNotification[] => {
+    if (typeof window === "undefined") {
+        return [];
+    }
+
+    const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+    if (!raw) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(raw) as VisitUrgentSharedNotification | VisitUrgentSharedNotification[];
+        const items = Array.isArray(parsed) ? parsed : [parsed];
+        const nowMs = Date.now();
+
+        const active = items.filter((item) => {
+            const expiresAtMs = Date.parse(item.expires_at);
+            return Number.isFinite(expiresAtMs) && expiresAtMs > nowMs;
+        });
+
+        if (active.length !== items.length) {
+            if (active.length === 0) {
+                globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+            } else {
+                globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+            }
+        }
+
+        return active.sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at));
+    } catch {
+        globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+        return [];
+    }
 };
 
 type HomeNotification = {
@@ -371,6 +416,19 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
         }];
     }, []);
 
+    const buildVisitUrgentItems = useCallback((): HomeNotification[] => {
+        const items = getActiveVisitUrgentNotifications();
+        return items.map((item) => ({
+            id: item.id,
+            title: item.title,
+            description: item.message,
+            time: formatRelativeTime(item.created_at),
+            type: "urgent" as const,
+            source: "visitors" as const,
+            createdAt: item.created_at,
+        }));
+    }, []);
+
     const loadHomeNotifications = useCallback(async (silent = false) => {
         const requestId = ++notificationsRequestIdRef.current;
         
@@ -398,6 +456,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             const mergedNotifications: HomeNotification[] = [
                 ...(announcementsRes.status === "fulfilled" ? buildAnnouncementItems(announcementsRes.value) : []),
                 ...(packagesRes.status === "fulfilled" ? buildPackageItems(packagesRes.value || 0) : []),
+                ...buildVisitUrgentItems(),
             ];
 
             // 4. Procesamiento de respuestas tipo Fetch (Incidencias y Eventos)
@@ -411,11 +470,20 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                 mergedNotifications.push(...buildEventItems(Array.isArray(eventsData) ? eventsData : []));
             }
 
-            const visibleNotifications = mergedNotifications.filter((notification) => !dismissedNotificationIdsRef.current.includes(notification.id));
+            const visibleNotifications = mergedNotifications.filter((notification) => (
+                notification.source === "visitors" || !dismissedNotificationIdsRef.current.includes(notification.id)
+            ));
 
             // 5. Ordenación y Límite
             const sorted = visibleNotifications
-                .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+                .sort((a, b) => {
+                    const aPinned = a.source === "visitors" ? 1 : 0;
+                    const bPinned = b.source === "visitors" ? 1 : 0;
+                    if (aPinned !== bPinned) {
+                        return bPinned - aPinned;
+                    }
+                    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+                })
                 .slice(0, NOTIFICATIONS_LIMIT);
 
             setNotifications(sorted);
@@ -427,7 +495,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                 setIsNotificationsLoading(false);
             }
         }
-    }, [buildAnnouncementItems, buildIncidenceItems, buildEventItems, buildPackageItems]);
+    }, [buildAnnouncementItems, buildIncidenceItems, buildEventItems, buildPackageItems, buildVisitUrgentItems]);
     useEffect(() => {
         loadHomeNotifications();
         const intervalId = globalThis.setInterval(() => loadHomeNotifications(true), NOTIFICATIONS_POLL);
@@ -469,6 +537,10 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
     };
 
     const handleDismissNotification = (notification: HomeNotification) => {
+        if (notification.source === "visitors") {
+            return;
+        }
+
         appendSeenNotificationIds([notification.id]);
         appendDismissedNotificationIds([notification.id]);
 
@@ -504,6 +576,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             case "announcements": return <Megaphone className="w-5 h-5 text-blue-600" />;
             case "incidences": return <AlertCircle className="w-5 h-5 text-orange-600" />;
             case "packages": return <Package className="w-5 h-5 text-green-600" />;
+            case "visitors": return <Users className="w-5 h-5 text-red-600" />;
             default: return <Calendar className="w-5 h-5 text-purple-600" />;
         }
     };
@@ -556,6 +629,7 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
                                                     description={notification.description}
                                                     time={notification.time}
                                                     type={notification.type}
+                                                    dismissible={notification.source !== "visitors"}
                                                     onDismiss={() => handleDismissNotification(notification)}
                                                     onOpenSource={() => {
                                                         if (notification.source === "incidences") {
@@ -682,6 +756,7 @@ interface NotificationCardProps {
     type: NotificationType;
     onDismiss: () => void;
     onOpenSource: () => void;
+    dismissible?: boolean;
 }
 
 interface QuickActionProps {
@@ -692,9 +767,9 @@ interface QuickActionProps {
     onClick: () => void;
 }
 
-function NotificationCard({ icon, title, description, time, type, onDismiss, onOpenSource }: NotificationCardProps) {
+function NotificationCard({ icon, title, description, time, type, onDismiss, onOpenSource, dismissible = true }: NotificationCardProps) {
     const bgColors: Record<NotificationType, string> = {
-        urgent: "bg-orange-50 border-orange-200",
+        urgent: "border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 shadow-[0_6px_18px_rgba(245,158,11,0.18)]",
         admin: "bg-blue-50 border-blue-200",
         event: "bg-yellow-50 border-yellow-200",
         info: "bg-gray-50 border-gray-200",
@@ -705,7 +780,7 @@ function NotificationCard({ icon, title, description, time, type, onDismiss, onO
     return (
         <div className={`relative w-full rounded-xl border ${bgColors[type] || bgColors.info} transition-colors hover:shadow-sm`}>
             <button
-                className="w-full p-4 pr-12 text-left"
+                className="w-full p-3 pr-10 text-left"
                 onClick={onOpenSource}
                 type="button"
             >
@@ -714,22 +789,24 @@ function NotificationCard({ icon, title, description, time, type, onDismiss, onO
                         {icon}
                     </div>
                     <div className="flex-1 min-w-0">
-                        <h4 className="font-bold text-gray-900 text-sm mb-1">{title}</h4>
-                        <p className="text-xs text-gray-600 mb-2">{description}</p>
+                        <h4 className="font-bold text-gray-900 text-sm mb-0.5">{title}</h4>
+                        <p className="text-xs text-gray-600 mb-1">{description}</p>
                         <p className="text-xs text-gray-400">{time}</p>
                     </div>
                 </div>
             </button>
-            <Button
-                aria-label={`Descartar notificación ${title}`}
-                className="absolute right-2 top-2 w-9 h-9 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all"
-                onClick={onDismiss}
-                size="icon"
-                type="button"
-                variant="ghost"
-            >
-                <X className="h-5 w-5" />
-            </Button>
+            {dismissible ? (
+                <Button
+                    aria-label={`Descartar notificación ${title}`}
+                    className="absolute right-2 top-2 w-9 h-9 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all"
+                    onClick={onDismiss}
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                >
+                    <X className="h-5 w-5" />
+                </Button>
+            ) : null}
         </div>
     );
 }

--- a/frontend/src/components/StudentHome.tsx
+++ b/frontend/src/components/StudentHome.tsx
@@ -166,7 +166,7 @@ const buildVisitUrgentNotificationStorageKey = (email: string): string | null =>
 };
 
 const getActiveVisitUrgentNotifications = (storageKey: string | null): VisitUrgentSharedNotification[] => {
-    if (typeof globalThis.window === "undefined" || !storageKey) {
+    if (globalThis.window === undefined || !storageKey) {
         return [];
     }
 

--- a/frontend/src/components/StudentHome.tsx
+++ b/frontend/src/components/StudentHome.tsx
@@ -166,7 +166,7 @@ const buildVisitUrgentNotificationStorageKey = (email: string): string | null =>
 };
 
 const getActiveVisitUrgentNotifications = (storageKey: string | null): VisitUrgentSharedNotification[] => {
-    if (typeof window === "undefined" || !storageKey) {
+    if (typeof globalThis.window === "undefined" || !storageKey) {
         return [];
     }
 
@@ -487,16 +487,16 @@ export function StudentHome({ onNavigate, onLogout }: StudentHomeProps) {
             ));
 
             // 5. Ordenación y Límite
-            const sorted = visibleNotifications
-                .sort((a, b) => {
-                    const aPinned = a.source === "visitors" ? 1 : 0;
-                    const bPinned = b.source === "visitors" ? 1 : 0;
-                    if (aPinned !== bPinned) {
-                        return bPinned - aPinned;
-                    }
-                    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
-                })
-                .slice(0, NOTIFICATIONS_LIMIT);
+            const sortedNotifications = [...visibleNotifications].sort((a, b) => {
+                const aPinned = a.source === "visitors" ? 1 : 0;
+                const bPinned = b.source === "visitors" ? 1 : 0;
+                if (aPinned !== bPinned) {
+                    return bPinned - aPinned;
+                }
+                return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+            });
+
+            const sorted = sortedNotifications.slice(0, NOTIFICATIONS_LIMIT);
 
             setNotifications(sorted);
 
@@ -779,7 +779,7 @@ interface QuickActionProps {
     onClick: () => void;
 }
 
-function NotificationCard({ icon, title, description, time, type, onDismiss, onOpenSource, dismissible = true }: NotificationCardProps) {
+function NotificationCard({ icon, title, description, time, type, onDismiss, onOpenSource, dismissible = true }: Readonly<NotificationCardProps>) {
     const bgColors: Record<NotificationType, string> = {
         urgent: "border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 shadow-[0_6px_18px_rgba(245,158,11,0.18)]",
         admin: "bg-blue-50 border-blue-200",

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -331,7 +331,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                 }
 
                 const sharedNotifications: VisitUrgentSharedNotification[] = expiringPasses.map((pass) => ({
-                    id: `visit-expiring-${pass.validUntilIso}`,
+                    id: `visit-expiring-${pass.passId}-${pass.validUntilIso}`,
                     title: "Pase de invitado por caducar",
                     message: `Quedan ${pass.minutesRemaining} min · Pase ${pass.passCode}`,
                     created_at: new Date().toISOString(),

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -33,7 +33,7 @@ const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
 const VISIT_URGENT_WARNING_WINDOW_MS = 10 * 60 * 1000;
 const VISIT_URGENT_CHECK_INTERVAL_MS = 30 * 1000;
 const VISIT_STATE_CHANGED_EVENT = "visit-state-changed";
-const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_KEY_BASE = "visit-urgent-shared-notifications";
 const VISIT_URGENT_NOTIFICATION_EVENT = "visit-urgent-notification-changed";
 
 type VisitUrgentSharedNotification = {
@@ -85,6 +85,12 @@ function buildGroupMessageEventKey(evt: ChatRealtimeEvent): string | null {
     return `${groupId}:fallback:${senderEmail || "unknown"}:${ts}`;
 }
 
+function buildVisitUrgentNotificationStorageKey(email: string): string | null {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) return null;
+    return `${VISIT_URGENT_NOTIFICATION_KEY_BASE}:${normalized}`;
+}
+
 export function StudentView({ onLogout }: StudentViewProps) {
     const [activeTab, setActiveTab] = useState<StudentTab>("home");
     const [unreadAnnouncements, setUnreadAnnouncements] = useState(0);
@@ -100,22 +106,23 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const processedGroupMessageEventKeysRef = useRef<Set<string>>(new Set());
     const notifiedExpiringPassesRef = useRef<Set<string>>(new Set());
     const urgentVisitCheckSequenceRef = useRef(0);
+    const visitUrgentStorageKey = buildVisitUrgentNotificationStorageKey(currentUserEmail);
 
     const hasAnyChatNews = hasGroupChatNews || hasPrivateChatNews;
 
     const syncVisitUrgentSharedNotifications = useCallback((payload: VisitUrgentSharedNotification[]) => {
-        if (typeof window === "undefined") {
+        if (typeof window === "undefined" || !visitUrgentStorageKey) {
             return;
         }
 
         if (!payload.length) {
-            globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+            globalThis.localStorage.removeItem(visitUrgentStorageKey);
             globalThis.dispatchEvent(new Event(VISIT_URGENT_NOTIFICATION_EVENT));
             return;
         }
 
         try {
-            const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+            const raw = globalThis.localStorage.getItem(visitUrgentStorageKey);
             const createdAtById = new Map<string, string>();
             if (raw) {
                 const parsed = JSON.parse(raw) as VisitUrgentSharedNotification | VisitUrgentSharedNotification[];
@@ -135,9 +142,9 @@ export function StudentView({ onLogout }: StudentViewProps) {
             // If existing payload is invalid, overwrite it below.
         }
 
-        globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(payload));
+        globalThis.localStorage.setItem(visitUrgentStorageKey, JSON.stringify(payload));
         globalThis.dispatchEvent(new Event(VISIT_URGENT_NOTIFICATION_EVENT));
-    }, []);
+    }, [visitUrgentStorageKey]);
 
     const isGroupLifecycleEvent = useCallback((evt: ChatRealtimeEvent): boolean =>
         evt.event === "group_created" || evt.event === "group_updated" || evt.event === "group_deleted", []);
@@ -281,16 +288,31 @@ export function StudentView({ onLogout }: StudentViewProps) {
     }, [activeTab]);
 
     useEffect(() => {
+        if (!visitUrgentStorageKey) {
+            return;
+        }
+
         let cancelled = false;
 
         const runUrgentVisitChecks = async () => {
             const currentSequence = ++urgentVisitCheckSequenceRef.current;
             try {
-                const [activePasses, upcomingPasses, policy] = await Promise.all([
-                    listMyActiveGuestPasses(),
-                    listMyUpcomingGuestPasses(),
-                    getMyGuestPassPolicy(),
-                ]);
+                let activePasses: Awaited<ReturnType<typeof listMyActiveGuestPasses>> = [];
+                let upcomingPasses: Awaited<ReturnType<typeof listMyUpcomingGuestPasses>> = [];
+
+                try {
+                    [activePasses, upcomingPasses] = await Promise.all([
+                        listMyActiveGuestPasses(),
+                        listMyUpcomingGuestPasses(),
+                    ]);
+                } catch {
+                    if (!cancelled && currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    syncVisitUrgentSharedNotifications([]);
+                    return;
+                }
+
                 if (cancelled || currentSequence !== urgentVisitCheckSequenceRef.current) return;
 
                 const nowMs = Date.now();
@@ -338,34 +360,42 @@ export function StudentView({ onLogout }: StudentViewProps) {
                     expires_at: pass.validUntilIso,
                     source: "visitors",
                 }));
-                syncVisitUrgentSharedNotifications(sharedNotifications);
 
-                const visitEndTime = policy.visit_end_time;
-                if (!visitEndTime) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
+                const hasActiveNow = activePasses.some((pass) => {
+                    const status = (pass.status || "").trim().toUpperCase();
+                    if (status && status !== "ACTIVE") {
+                        return false;
                     }
-                    return;
-                }
 
-                const startOfToday = new Date();
-                startOfToday.setHours(0, 0, 0, 0);
-                const startOfTomorrow = new Date(startOfToday);
-                startOfTomorrow.setDate(startOfTomorrow.getDate() + 1);
-
-                const hasVisitForToday = allRelevantPasses.some((pass) => {
                     const validFromMs = new Date(pass.valid_from).getTime();
                     const validUntilMs = new Date(pass.valid_until).getTime();
                     if (Number.isNaN(validFromMs) || Number.isNaN(validUntilMs)) {
                         return false;
                     }
-                    return validFromMs < startOfTomorrow.getTime() && validUntilMs > startOfToday.getTime();
+                    return validFromMs <= nowMs && nowMs < validUntilMs;
                 });
 
-                if (!hasVisitForToday) {
+                if (!hasActiveNow) {
                     if (currentSequence === urgentVisitCheckSequenceRef.current) {
                         setVisitLimitBanner(null);
                     }
+                    syncVisitUrgentSharedNotifications(sharedNotifications);
+                    return;
+                }
+
+                let policy: Awaited<ReturnType<typeof getMyGuestPassPolicy>> | null = null;
+                try {
+                    policy = await getMyGuestPassPolicy();
+                } catch {
+                    policy = null;
+                }
+
+                const visitEndTime = policy?.visit_end_time;
+                if (!visitEndTime) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
@@ -376,6 +406,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                     if (currentSequence === urgentVisitCheckSequenceRef.current) {
                         setVisitLimitBanner(null);
                     }
+                    syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
@@ -386,6 +417,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                     if (currentSequence === urgentVisitCheckSequenceRef.current) {
                         setVisitLimitBanner(null);
                     }
+                    syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
@@ -394,6 +426,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                     if (currentSequence === urgentVisitCheckSequenceRef.current) {
                         setVisitLimitBanner(null);
                     }
+                    syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
@@ -402,7 +435,9 @@ export function StudentView({ onLogout }: StudentViewProps) {
                 if (currentSequence !== urgentVisitCheckSequenceRef.current || cancelled) {
                     return;
                 }
+
                 setVisitLimitBanner({ minutesRemaining, visitEndLabel });
+                syncVisitUrgentSharedNotifications(sharedNotifications);
             } catch {
                 if (!cancelled && currentSequence === urgentVisitCheckSequenceRef.current) {
                     setVisitLimitBanner(null);
@@ -425,7 +460,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
             globalThis.clearInterval(intervalId);
             globalThis.removeEventListener(VISIT_STATE_CHANGED_EVENT, handleVisitStateChanged);
         };
-    }, [syncVisitUrgentSharedNotifications]);
+    }, [syncVisitUrgentSharedNotifications, visitUrgentStorageKey]);
 
     useEffect(() => {
         if (activeTab === "announcements") {

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -220,7 +220,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const hasAnyChatNews = hasGroupChatNews || hasPrivateChatNews;
 
     const syncVisitUrgentSharedNotifications = useCallback((payload: VisitUrgentSharedNotification[]) => {
-        if (typeof window === "undefined" || !visitUrgentStorageKey) {
+        if (globalThis.window === undefined || !visitUrgentStorageKey) {
             return;
         }
 

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
-import { AlertCircle, Calendar, Home, MessageSquare, User } from "lucide-react";
+import { AlertCircle, AlertTriangle, Calendar, Home, MessageSquare, User } from "lucide-react";
 import { toast } from "sonner";
 
 // Importamos la página de inicio y el tipo de las pestañas
@@ -19,12 +19,31 @@ import { chatsService, type ChatRealtimeEvent } from "../services/chats";
 import { authService } from "../services/auth";
 import { ActiveGuestPassesPage } from "../pages/Visitors/ActiveGuestPasses";
 import type { ResidenceBranding } from "../services/branding";
+import {
+    getMyGuestPassPolicy,
+    listMyActiveGuestPasses,
+    listMyUpcomingGuestPasses,
+} from "../services/guestPasses";
 
 interface StudentViewProps {
     onLogout: () => void;
 }
 
 const HOME_ANNOUNCEMENTS_SEEN_AT_KEY = "home-announcements-seen-at";
+const VISIT_URGENT_WARNING_WINDOW_MS = 10 * 60 * 1000;
+const VISIT_URGENT_CHECK_INTERVAL_MS = 30 * 1000;
+const VISIT_STATE_CHANGED_EVENT = "visit-state-changed";
+const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_EVENT = "visit-urgent-notification-changed";
+
+type VisitUrgentSharedNotification = {
+    id: string;
+    title: string;
+    message: string;
+    created_at: string;
+    expires_at: string;
+    source: "visitors";
+};
 
 function buildResidentUnreadGroupsStorageKey(email: string): string | null {
     const normalized = email.trim().toLowerCase();
@@ -76,10 +95,49 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const [communityChatSubTab, setCommunityChatSubTab] = useState<"grupos" | "privados" | null>(null);
     const [hasGroupChatNews, setHasGroupChatNews] = useState(false);
     const [hasPrivateChatNews, setHasPrivateChatNews] = useState(false);
+    const [visitLimitBanner, setVisitLimitBanner] = useState<{ minutesRemaining: number; visitEndLabel: string } | null>(null);
     const previousUnreadCount = useRef<number | null>(null);
     const processedGroupMessageEventKeysRef = useRef<Set<string>>(new Set());
+    const notifiedExpiringPassesRef = useRef<Set<string>>(new Set());
+    const urgentVisitCheckSequenceRef = useRef(0);
 
     const hasAnyChatNews = hasGroupChatNews || hasPrivateChatNews;
+
+    const syncVisitUrgentSharedNotifications = useCallback((payload: VisitUrgentSharedNotification[]) => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        if (!payload.length) {
+            globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+            globalThis.dispatchEvent(new Event(VISIT_URGENT_NOTIFICATION_EVENT));
+            return;
+        }
+
+        try {
+            const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+            const createdAtById = new Map<string, string>();
+            if (raw) {
+                const parsed = JSON.parse(raw) as VisitUrgentSharedNotification | VisitUrgentSharedNotification[];
+                const currentItems = Array.isArray(parsed) ? parsed : [parsed];
+                for (const item of currentItems) {
+                    if (item?.id && item?.created_at) {
+                        createdAtById.set(item.id, item.created_at);
+                    }
+                }
+            }
+
+            payload = payload.map((item) => ({
+                ...item,
+                created_at: createdAtById.get(item.id) || item.created_at,
+            }));
+        } catch {
+            // If existing payload is invalid, overwrite it below.
+        }
+
+        globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(payload));
+        globalThis.dispatchEvent(new Event(VISIT_URGENT_NOTIFICATION_EVENT));
+    }, []);
 
     const isGroupLifecycleEvent = useCallback((evt: ChatRealtimeEvent): boolean =>
         evt.event === "group_created" || evt.event === "group_updated" || evt.event === "group_deleted", []);
@@ -223,6 +281,153 @@ export function StudentView({ onLogout }: StudentViewProps) {
     }, [activeTab]);
 
     useEffect(() => {
+        let cancelled = false;
+
+        const runUrgentVisitChecks = async () => {
+            const currentSequence = ++urgentVisitCheckSequenceRef.current;
+            try {
+                const [activePasses, upcomingPasses, policy] = await Promise.all([
+                    listMyActiveGuestPasses(),
+                    listMyUpcomingGuestPasses(),
+                    getMyGuestPassPolicy(),
+                ]);
+                if (cancelled || currentSequence !== urgentVisitCheckSequenceRef.current) return;
+
+                const nowMs = Date.now();
+                const allRelevantPasses = [...activePasses, ...upcomingPasses];
+
+                const expiringPasses = allRelevantPasses
+                    .map((pass) => {
+                        const validUntilMs = new Date(pass.valid_until).getTime();
+                        if (Number.isNaN(validUntilMs) || validUntilMs <= nowMs) {
+                            return null;
+                        }
+
+                        const timeRemainingMs = validUntilMs - nowMs;
+                        if (timeRemainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
+                            return null;
+                        }
+
+                        return {
+                            passCode: pass.pass_code,
+                            validUntilIso: pass.valid_until,
+                            minutesRemaining: Math.max(1, Math.ceil(timeRemainingMs / 60000)),
+                            passId: pass.id,
+                        };
+                    })
+                    .filter((item): item is { passCode: string; validUntilIso: string; minutesRemaining: number; passId: number } => Boolean(item))
+                    .sort((a, b) => Date.parse(a.validUntilIso) - Date.parse(b.validUntilIso));
+
+                for (const pass of expiringPasses) {
+                    const passWarningKey = `${pass.passId}-${pass.validUntilIso}`;
+                    if (notifiedExpiringPassesRef.current.has(passWarningKey)) {
+                        continue;
+                    }
+
+                    notifiedExpiringPassesRef.current.add(passWarningKey);
+                    toast.warning("Tu pase está a punto de caducar", {
+                        description: `Quedan ${pass.minutesRemaining} min para que caduque el pase ${pass.passCode}.`,
+                    });
+                }
+
+                const sharedNotifications: VisitUrgentSharedNotification[] = expiringPasses.map((pass) => ({
+                    id: `visit-expiring-${pass.validUntilIso}`,
+                    title: "Pase de invitado por caducar",
+                    message: `Quedan ${pass.minutesRemaining} min · Pase ${pass.passCode}`,
+                    created_at: new Date().toISOString(),
+                    expires_at: pass.validUntilIso,
+                    source: "visitors",
+                }));
+                syncVisitUrgentSharedNotifications(sharedNotifications);
+
+                const visitEndTime = policy.visit_end_time;
+                if (!visitEndTime) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    return;
+                }
+
+                const startOfToday = new Date();
+                startOfToday.setHours(0, 0, 0, 0);
+                const startOfTomorrow = new Date(startOfToday);
+                startOfTomorrow.setDate(startOfTomorrow.getDate() + 1);
+
+                const hasVisitForToday = allRelevantPasses.some((pass) => {
+                    const validFromMs = new Date(pass.valid_from).getTime();
+                    const validUntilMs = new Date(pass.valid_until).getTime();
+                    if (Number.isNaN(validFromMs) || Number.isNaN(validUntilMs)) {
+                        return false;
+                    }
+                    return validFromMs < startOfTomorrow.getTime() && validUntilMs > startOfToday.getTime();
+                });
+
+                if (!hasVisitForToday) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    return;
+                }
+
+                const [hoursPart, minutesPart] = visitEndTime.slice(0, 5).split(":");
+                const visitEndHour = Number(hoursPart);
+                const visitEndMinute = Number(minutesPart);
+                if (!Number.isInteger(visitEndHour) || !Number.isInteger(visitEndMinute)) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    return;
+                }
+
+                const todayVisitEnd = new Date();
+                todayVisitEnd.setHours(visitEndHour, visitEndMinute, 0, 0);
+                const visitEndMs = todayVisitEnd.getTime();
+                if (visitEndMs <= nowMs) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    return;
+                }
+
+                const remainingMs = visitEndMs - nowMs;
+                if (remainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
+                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
+                        setVisitLimitBanner(null);
+                    }
+                    return;
+                }
+
+                const minutesRemaining = Math.max(1, Math.ceil(remainingMs / 60000));
+                const visitEndLabel = visitEndTime.slice(0, 5);
+                if (currentSequence !== urgentVisitCheckSequenceRef.current || cancelled) {
+                    return;
+                }
+                setVisitLimitBanner({ minutesRemaining, visitEndLabel });
+            } catch {
+                if (!cancelled && currentSequence === urgentVisitCheckSequenceRef.current) {
+                    setVisitLimitBanner(null);
+                }
+                syncVisitUrgentSharedNotifications([]);
+            }
+        };
+
+        void runUrgentVisitChecks();
+        const handleVisitStateChanged = () => {
+            void runUrgentVisitChecks();
+        };
+        globalThis.addEventListener(VISIT_STATE_CHANGED_EVENT, handleVisitStateChanged);
+        const intervalId = globalThis.setInterval(() => {
+            void runUrgentVisitChecks();
+        }, VISIT_URGENT_CHECK_INTERVAL_MS);
+
+        return () => {
+            cancelled = true;
+            globalThis.clearInterval(intervalId);
+            globalThis.removeEventListener(VISIT_STATE_CHANGED_EVENT, handleVisitStateChanged);
+        };
+    }, [syncVisitUrgentSharedNotifications]);
+
+    useEffect(() => {
         if (activeTab === "announcements") {
             globalThis.localStorage.setItem(HOME_ANNOUNCEMENTS_SEEN_AT_KEY, new Date().toISOString());
         }
@@ -346,6 +551,20 @@ export function StudentView({ onLogout }: StudentViewProps) {
 
     return (
         <div className="min-h-screen w-full bg-background relative pb-20">
+            {visitLimitBanner ? (
+                <div className="pointer-events-none fixed left-1/2 top-2 z-50 w-[calc(100%-1rem)] max-w-lg -translate-x-1/2 rounded-lg border border-amber-300 bg-amber-100/95 px-3 py-2 text-amber-900 shadow-lg sm:top-3 sm:px-4 sm:py-2.5">
+                    <div className="flex items-start gap-2 sm:gap-3">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 sm:h-5 sm:w-5" />
+                        <div className="min-w-0">
+                            <p className="text-xs font-semibold leading-tight sm:text-sm">AVISO URGENTE DE VISITAS</p>
+                            <p className="text-xs leading-tight sm:text-sm">
+                                Quedan <strong>{visitLimitBanner.minutesRemaining} min</strong> ({visitLimitBanner.visitEndLabel}). Las visitas deben salir cuanto antes.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+
             <div className="w-full">
                 {renderContent()}
             </div>

--- a/frontend/src/components/StudentView.tsx
+++ b/frontend/src/components/StudentView.tsx
@@ -45,6 +45,115 @@ type VisitUrgentSharedNotification = {
     source: "visitors";
 };
 
+type GuestPassItem = Awaited<ReturnType<typeof listMyActiveGuestPasses>>[number];
+
+type ExpiringPassWarning = {
+    passCode: string;
+    validUntilIso: string;
+    minutesRemaining: number;
+    passId: number;
+};
+
+type VisitLimitBannerState = {
+    minutesRemaining: number;
+    visitEndLabel: string;
+};
+
+function getExpiringPassWarnings(passes: GuestPassItem[], nowMs: number): ExpiringPassWarning[] {
+    return passes
+        .map((pass) => {
+            const validUntilMs = new Date(pass.valid_until).getTime();
+            if (Number.isNaN(validUntilMs) || validUntilMs <= nowMs) {
+                return null;
+            }
+
+            const timeRemainingMs = validUntilMs - nowMs;
+            if (timeRemainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
+                return null;
+            }
+
+            return {
+                passCode: pass.pass_code,
+                validUntilIso: pass.valid_until,
+                minutesRemaining: Math.max(1, Math.ceil(timeRemainingMs / 60000)),
+                passId: pass.id,
+            };
+        })
+        .filter((item): item is ExpiringPassWarning => Boolean(item))
+        .sort((a, b) => Date.parse(a.validUntilIso) - Date.parse(b.validUntilIso));
+}
+
+function isPassActiveNow(pass: GuestPassItem, nowMs: number): boolean {
+    const status = (pass.status || "").trim().toUpperCase();
+    if (status && status !== "ACTIVE") {
+        return false;
+    }
+
+    const validFromMs = new Date(pass.valid_from).getTime();
+    const validUntilMs = new Date(pass.valid_until).getTime();
+    if (Number.isNaN(validFromMs) || Number.isNaN(validUntilMs)) {
+        return false;
+    }
+
+    return validFromMs <= nowMs && nowMs < validUntilMs;
+}
+
+function buildVisitUrgentSharedNotifications(expiringPasses: ExpiringPassWarning[]): VisitUrgentSharedNotification[] {
+    return expiringPasses.map((pass) => ({
+        id: `visit-expiring-${pass.passId}-${pass.validUntilIso}`,
+        title: "Pase de invitado por caducar",
+        message: `Quedan ${pass.minutesRemaining} min · Pase ${pass.passCode}`,
+        created_at: new Date().toISOString(),
+        expires_at: pass.validUntilIso,
+        source: "visitors",
+    }));
+}
+
+function getVisitLimitBannerState(visitEndTime: string, nowMs: number): VisitLimitBannerState | null {
+    const [hoursPart, minutesPart] = visitEndTime.slice(0, 5).split(":");
+    const visitEndHour = Number(hoursPart);
+    const visitEndMinute = Number(minutesPart);
+    if (!Number.isInteger(visitEndHour) || !Number.isInteger(visitEndMinute)) {
+        return null;
+    }
+
+    const todayVisitEnd = new Date();
+    todayVisitEnd.setHours(visitEndHour, visitEndMinute, 0, 0);
+    const visitEndMs = todayVisitEnd.getTime();
+    if (visitEndMs <= nowMs) {
+        return null;
+    }
+
+    const remainingMs = visitEndMs - nowMs;
+    if (remainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
+        return null;
+    }
+
+    return {
+        minutesRemaining: Math.max(1, Math.ceil(remainingMs / 60000)),
+        visitEndLabel: visitEndTime.slice(0, 5),
+    };
+}
+
+function shouldApplyCurrentVisitCheck(
+    cancelled: boolean,
+    currentSequence: number,
+    sequenceRef: React.MutableRefObject<number>,
+): boolean {
+    return !cancelled && currentSequence === sequenceRef.current;
+}
+
+function clearVisitLimitBannerIfCurrent(
+    setVisitLimitBanner: (value: VisitLimitBannerState | null) => void,
+    cancelled: boolean,
+    currentSequence: number,
+    sequenceRef: React.MutableRefObject<number>,
+): void {
+    if (shouldApplyCurrentVisitCheck(cancelled, currentSequence, sequenceRef)) {
+        setVisitLimitBanner(null);
+    }
+}
+
 function buildResidentUnreadGroupsStorageKey(email: string): string | null {
     const normalized = email.trim().toLowerCase();
     if (!normalized) return null;
@@ -101,7 +210,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
     const [communityChatSubTab, setCommunityChatSubTab] = useState<"grupos" | "privados" | null>(null);
     const [hasGroupChatNews, setHasGroupChatNews] = useState(false);
     const [hasPrivateChatNews, setHasPrivateChatNews] = useState(false);
-    const [visitLimitBanner, setVisitLimitBanner] = useState<{ minutesRemaining: number; visitEndLabel: string } | null>(null);
+    const [visitLimitBanner, setVisitLimitBanner] = useState<VisitLimitBannerState | null>(null);
     const previousUnreadCount = useRef<number | null>(null);
     const processedGroupMessageEventKeysRef = useRef<Set<string>>(new Set());
     const notifiedExpiringPassesRef = useRef<Set<string>>(new Set());
@@ -306,9 +415,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
                         listMyUpcomingGuestPasses(),
                     ]);
                 } catch {
-                    if (!cancelled && currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
+                    clearVisitLimitBannerIfCurrent(setVisitLimitBanner, cancelled, currentSequence, urgentVisitCheckSequenceRef);
                     syncVisitUrgentSharedNotifications([]);
                     return;
                 }
@@ -317,28 +424,7 @@ export function StudentView({ onLogout }: StudentViewProps) {
 
                 const nowMs = Date.now();
                 const allRelevantPasses = [...activePasses, ...upcomingPasses];
-
-                const expiringPasses = allRelevantPasses
-                    .map((pass) => {
-                        const validUntilMs = new Date(pass.valid_until).getTime();
-                        if (Number.isNaN(validUntilMs) || validUntilMs <= nowMs) {
-                            return null;
-                        }
-
-                        const timeRemainingMs = validUntilMs - nowMs;
-                        if (timeRemainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
-                            return null;
-                        }
-
-                        return {
-                            passCode: pass.pass_code,
-                            validUntilIso: pass.valid_until,
-                            minutesRemaining: Math.max(1, Math.ceil(timeRemainingMs / 60000)),
-                            passId: pass.id,
-                        };
-                    })
-                    .filter((item): item is { passCode: string; validUntilIso: string; minutesRemaining: number; passId: number } => Boolean(item))
-                    .sort((a, b) => Date.parse(a.validUntilIso) - Date.parse(b.validUntilIso));
+                const expiringPasses = getExpiringPassWarnings(allRelevantPasses, nowMs);
 
                 for (const pass of expiringPasses) {
                     const passWarningKey = `${pass.passId}-${pass.validUntilIso}`;
@@ -352,33 +438,11 @@ export function StudentView({ onLogout }: StudentViewProps) {
                     });
                 }
 
-                const sharedNotifications: VisitUrgentSharedNotification[] = expiringPasses.map((pass) => ({
-                    id: `visit-expiring-${pass.passId}-${pass.validUntilIso}`,
-                    title: "Pase de invitado por caducar",
-                    message: `Quedan ${pass.minutesRemaining} min · Pase ${pass.passCode}`,
-                    created_at: new Date().toISOString(),
-                    expires_at: pass.validUntilIso,
-                    source: "visitors",
-                }));
-
-                const hasActiveNow = activePasses.some((pass) => {
-                    const status = (pass.status || "").trim().toUpperCase();
-                    if (status && status !== "ACTIVE") {
-                        return false;
-                    }
-
-                    const validFromMs = new Date(pass.valid_from).getTime();
-                    const validUntilMs = new Date(pass.valid_until).getTime();
-                    if (Number.isNaN(validFromMs) || Number.isNaN(validUntilMs)) {
-                        return false;
-                    }
-                    return validFromMs <= nowMs && nowMs < validUntilMs;
-                });
+                const sharedNotifications = buildVisitUrgentSharedNotifications(expiringPasses);
+                const hasActiveNow = activePasses.some((pass) => isPassActiveNow(pass, nowMs));
 
                 if (!hasActiveNow) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
+                    clearVisitLimitBannerIfCurrent(setVisitLimitBanner, cancelled, currentSequence, urgentVisitCheckSequenceRef);
                     syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
@@ -392,56 +456,26 @@ export function StudentView({ onLogout }: StudentViewProps) {
 
                 const visitEndTime = policy?.visit_end_time;
                 if (!visitEndTime) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
+                    clearVisitLimitBannerIfCurrent(setVisitLimitBanner, cancelled, currentSequence, urgentVisitCheckSequenceRef);
                     syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
-                const [hoursPart, minutesPart] = visitEndTime.slice(0, 5).split(":");
-                const visitEndHour = Number(hoursPart);
-                const visitEndMinute = Number(minutesPart);
-                if (!Number.isInteger(visitEndHour) || !Number.isInteger(visitEndMinute)) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
+                const nextBannerState = getVisitLimitBannerState(visitEndTime, nowMs);
+                if (!nextBannerState) {
+                    clearVisitLimitBannerIfCurrent(setVisitLimitBanner, cancelled, currentSequence, urgentVisitCheckSequenceRef);
                     syncVisitUrgentSharedNotifications(sharedNotifications);
                     return;
                 }
 
-                const todayVisitEnd = new Date();
-                todayVisitEnd.setHours(visitEndHour, visitEndMinute, 0, 0);
-                const visitEndMs = todayVisitEnd.getTime();
-                if (visitEndMs <= nowMs) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
-                    syncVisitUrgentSharedNotifications(sharedNotifications);
+                if (!shouldApplyCurrentVisitCheck(cancelled, currentSequence, urgentVisitCheckSequenceRef)) {
                     return;
                 }
 
-                const remainingMs = visitEndMs - nowMs;
-                if (remainingMs > VISIT_URGENT_WARNING_WINDOW_MS) {
-                    if (currentSequence === urgentVisitCheckSequenceRef.current) {
-                        setVisitLimitBanner(null);
-                    }
-                    syncVisitUrgentSharedNotifications(sharedNotifications);
-                    return;
-                }
-
-                const minutesRemaining = Math.max(1, Math.ceil(remainingMs / 60000));
-                const visitEndLabel = visitEndTime.slice(0, 5);
-                if (currentSequence !== urgentVisitCheckSequenceRef.current || cancelled) {
-                    return;
-                }
-
-                setVisitLimitBanner({ minutesRemaining, visitEndLabel });
+                setVisitLimitBanner(nextBannerState);
                 syncVisitUrgentSharedNotifications(sharedNotifications);
             } catch {
-                if (!cancelled && currentSequence === urgentVisitCheckSequenceRef.current) {
-                    setVisitLimitBanner(null);
-                }
+                clearVisitLimitBannerIfCurrent(setVisitLimitBanner, cancelled, currentSequence, urgentVisitCheckSequenceRef);
                 syncVisitUrgentSharedNotifications([]);
             }
         };

--- a/frontend/src/components/announcement/NotificationBell.tsx
+++ b/frontend/src/components/announcement/NotificationBell.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from "react";
 import { cn } from "../ui/utils";
 import { toast } from "sonner";
 import announcementService from "../../services/announcement.service";
+import { authService } from "../../services/auth";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 interface NotificationBellProps {
@@ -11,7 +12,7 @@ interface NotificationBellProps {
   mode?: "notifications" | "announcements";
 }
 
-const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_KEY_BASE = "visit-urgent-shared-notifications";
 const VISIT_URGENT_NOTIFICATION_EVENT = "visit-urgent-notification-changed";
 
 type VisitUrgentSharedNotification = {
@@ -23,12 +24,20 @@ type VisitUrgentSharedNotification = {
   source: "visitors";
 };
 
-function getActiveVisitUrgentNotifications(): VisitUrgentSharedNotification[] {
-  if (typeof window === "undefined") {
+function buildVisitUrgentNotificationStorageKey(email: string): string | null {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return `${VISIT_URGENT_NOTIFICATION_KEY_BASE}:${normalized}`;
+}
+
+function getActiveVisitUrgentNotifications(storageKey: string | null): VisitUrgentSharedNotification[] {
+  if (typeof window === "undefined" || !storageKey) {
     return [];
   }
 
-  const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+  const raw = globalThis.localStorage.getItem(storageKey);
   if (!raw) {
     return [];
   }
@@ -45,15 +54,15 @@ function getActiveVisitUrgentNotifications(): VisitUrgentSharedNotification[] {
 
     if (active.length !== items.length) {
       if (active.length === 0) {
-        globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+        globalThis.localStorage.removeItem(storageKey);
       } else {
-        globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+        globalThis.localStorage.setItem(storageKey, JSON.stringify(active));
       }
     }
 
     return active.sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at));
   } catch {
-    globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+    globalThis.localStorage.removeItem(storageKey);
     return [];
   }
 }
@@ -61,8 +70,10 @@ function getActiveVisitUrgentNotifications(): VisitUrgentSharedNotification[] {
 export function NotificationBell({ onMarkAsRead, className, mode = "notifications" }: NotificationBellProps) {
   const [unviewedCount, setUnviewedCount] = useState(0);
   const [visitUrgentNotifications, setVisitUrgentNotifications] = useState<VisitUrgentSharedNotification[]>([]);
+  const [currentUserEmail, setCurrentUserEmail] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const visitUrgentStorageKey = buildVisitUrgentNotificationStorageKey(currentUserEmail);
   const totalNotifications = unviewedCount + visitUrgentNotifications.length;
   const hasNotifications = totalNotifications > 0;
   const isAnnouncementsMode = mode === "announcements";
@@ -75,9 +86,9 @@ export function NotificationBell({ onMarkAsRead, className, mode = "notification
   const refreshBellState = useCallback(async (): Promise<number> => {
     const data = await announcementService.getUnviewedCount();
     setUnviewedCount(data.count);
-    setVisitUrgentNotifications(getActiveVisitUrgentNotifications());
+    setVisitUrgentNotifications(getActiveVisitUrgentNotifications(visitUrgentStorageKey));
     return data.count;
-  }, []);
+  }, [visitUrgentStorageKey]);
 
   const loadUnviewedCount = useCallback(async () => {
     try {
@@ -88,10 +99,20 @@ export function NotificationBell({ onMarkAsRead, className, mode = "notification
   }, [refreshBellState]);
 
   useEffect(() => {
+    authService.me()
+      .then((session) => {
+        setCurrentUserEmail((session.user?.email || "").trim().toLowerCase());
+      })
+      .catch(() => {
+        setCurrentUserEmail("");
+      });
+  }, []);
+
+  useEffect(() => {
     void loadUnviewedCount();
 
     const refreshVisitUrgentNotifications = () => {
-      setVisitUrgentNotifications(getActiveVisitUrgentNotifications());
+      setVisitUrgentNotifications(getActiveVisitUrgentNotifications(visitUrgentStorageKey));
     };
 
     refreshVisitUrgentNotifications();
@@ -102,7 +123,7 @@ export function NotificationBell({ onMarkAsRead, className, mode = "notification
       globalThis.removeEventListener(VISIT_URGENT_NOTIFICATION_EVENT, refreshVisitUrgentNotifications);
       globalThis.clearInterval(intervalId);
     };
-  }, [loadUnviewedCount]);
+  }, [loadUnviewedCount, visitUrgentStorageKey]);
 
   const handleBellClick = async () => {
     setLoading(true);

--- a/frontend/src/components/announcement/NotificationBell.tsx
+++ b/frontend/src/components/announcement/NotificationBell.tsx
@@ -33,7 +33,7 @@ function buildVisitUrgentNotificationStorageKey(email: string): string | null {
 }
 
 function getActiveVisitUrgentNotifications(storageKey: string | null): VisitUrgentSharedNotification[] {
-  if (typeof window === "undefined" || !storageKey) {
+  if (typeof globalThis.window === "undefined" || !storageKey) {
     return [];
   }
 
@@ -109,7 +109,9 @@ export function NotificationBell({ onMarkAsRead, className, mode = "notification
   }, []);
 
   useEffect(() => {
-    void loadUnviewedCount();
+    loadUnviewedCount().catch((error) => {
+      console.error("Error loading unviewed count:", error);
+    });
 
     const refreshVisitUrgentNotifications = () => {
       setVisitUrgentNotifications(getActiveVisitUrgentNotifications(visitUrgentStorageKey));

--- a/frontend/src/components/announcement/NotificationBell.tsx
+++ b/frontend/src/components/announcement/NotificationBell.tsx
@@ -33,7 +33,7 @@ function buildVisitUrgentNotificationStorageKey(email: string): string | null {
 }
 
 function getActiveVisitUrgentNotifications(storageKey: string | null): VisitUrgentSharedNotification[] {
-  if (typeof globalThis.window === "undefined" || !storageKey) {
+  if (globalThis.window === undefined || !storageKey) {
     return [];
   }
 

--- a/frontend/src/components/announcement/NotificationBell.tsx
+++ b/frontend/src/components/announcement/NotificationBell.tsx
@@ -1,8 +1,9 @@
-import { Bell } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { AlertTriangle, Bell } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
 import { cn } from "../ui/utils";
 import { toast } from "sonner";
 import announcementService from "../../services/announcement.service";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 interface NotificationBellProps {
   onMarkAsRead?: () => void;
@@ -10,76 +11,105 @@ interface NotificationBellProps {
   mode?: "notifications" | "announcements";
 }
 
-const TOAST_COOLDOWN_MS = 3500; // Tiempo para no repetir el mismo toast de notificación
-const TOAST_DURATION_MS = 2000;
+const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_EVENT = "visit-urgent-notification-changed";
+
+type VisitUrgentSharedNotification = {
+  id: string;
+  title: string;
+  message: string;
+  created_at: string;
+  expires_at: string;
+  source: "visitors";
+};
+
+function getActiveVisitUrgentNotifications(): VisitUrgentSharedNotification[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = globalThis.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as VisitUrgentSharedNotification | VisitUrgentSharedNotification[];
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    const nowMs = Date.now();
+
+    const active = items.filter((item) => {
+      const expiresAtMs = Date.parse(item.expires_at);
+      return Number.isFinite(expiresAtMs) && expiresAtMs > nowMs;
+    });
+
+    if (active.length !== items.length) {
+      if (active.length === 0) {
+        globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+      } else {
+        globalThis.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+      }
+    }
+
+    return active.sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at));
+  } catch {
+    globalThis.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+    return [];
+  }
+}
 
 export function NotificationBell({ onMarkAsRead, className, mode = "notifications" }: NotificationBellProps) {
   const [unviewedCount, setUnviewedCount] = useState(0);
+  const [visitUrgentNotifications, setVisitUrgentNotifications] = useState<VisitUrgentSharedNotification[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const lastEmptyToastTimeRef = useRef<number>(0);
-  const activeToastIdRef = useRef<string | number | undefined>(undefined);
-  const hasNotifications = unviewedCount > 0;
+  const totalNotifications = unviewedCount + visitUrgentNotifications.length;
+  const hasNotifications = totalNotifications > 0;
   const isAnnouncementsMode = mode === "announcements";
 
   const title = isAnnouncementsMode ? "Avisos" : "Notificaciones";
   const emptyDescription = isAnnouncementsMode
     ? "No tienes avisos nuevos"
     : "No tienes notificaciones nuevas";
-  const singularLabel = isAnnouncementsMode ? "aviso" : "notificación";
 
-  useEffect(() => {
-    loadUnviewedCount();
+  const refreshBellState = useCallback(async (): Promise<number> => {
+    const data = await announcementService.getUnviewedCount();
+    setUnviewedCount(data.count);
+    setVisitUrgentNotifications(getActiveVisitUrgentNotifications());
+    return data.count;
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (activeToastIdRef.current !== undefined) {
-        toast.dismiss(activeToastIdRef.current);
-        activeToastIdRef.current = undefined;
-      }
-    };
-  }, []);
-
-  const loadUnviewedCount = async () => {
+  const loadUnviewedCount = useCallback(async () => {
     try {
-      const data = await announcementService.getUnviewedCount();
-      setUnviewedCount(data.count);
+      await refreshBellState();
     } catch (error) {
       console.error("Error loading unviewed count:", error);
     }
-  };
+  }, [refreshBellState]);
+
+  useEffect(() => {
+    void loadUnviewedCount();
+
+    const refreshVisitUrgentNotifications = () => {
+      setVisitUrgentNotifications(getActiveVisitUrgentNotifications());
+    };
+
+    refreshVisitUrgentNotifications();
+    globalThis.addEventListener(VISIT_URGENT_NOTIFICATION_EVENT, refreshVisitUrgentNotifications);
+    const intervalId = globalThis.setInterval(refreshVisitUrgentNotifications, 30000);
+
+    return () => {
+      globalThis.removeEventListener(VISIT_URGENT_NOTIFICATION_EVENT, refreshVisitUrgentNotifications);
+      globalThis.clearInterval(intervalId);
+    };
+  }, [loadUnviewedCount]);
 
   const handleBellClick = async () => {
     setLoading(true);
     try {
-      const data = await announcementService.getUnviewedCount();
-      setUnviewedCount(data.count);
+      const unreadAnnouncements = await refreshBellState();
 
-      if (data.count === 0) {
-        const now = Date.now();
-        // Solo mostrar el toast de "no hay avisos" si ha pasado el cooldown
-        if (now - lastEmptyToastTimeRef.current > TOAST_COOLDOWN_MS) {
-          if (activeToastIdRef.current !== undefined) {
-            toast.dismiss(activeToastIdRef.current);
-          }
-          activeToastIdRef.current = toast.info(title, {
-            description: emptyDescription,
-            duration: TOAST_DURATION_MS,
-          });
-          lastEmptyToastTimeRef.current = now;
-        }
-      } else {
-        // Si hay avisos, resetear el cooldown para permitir mostrar de nuevo
-        lastEmptyToastTimeRef.current = 0;
-        const pluralSuffix = data.count !== 1 ? "s" : "";
-        if (activeToastIdRef.current !== undefined) {
-          toast.dismiss(activeToastIdRef.current);
-        }
-        activeToastIdRef.current = toast.info(title, {
-          description: `Tienes ${data.count} ${singularLabel}${pluralSuffix} nueva${pluralSuffix}`,
-          duration: TOAST_DURATION_MS,
-        });
-
+      if (unreadAnnouncements > 0) {
         await announcementService.markAsViewed();
         setUnviewedCount(0);
       }
@@ -87,30 +117,68 @@ export function NotificationBell({ onMarkAsRead, className, mode = "notification
       onMarkAsRead?.();
     } catch (error) {
       console.error("Error loading unviewed count:", error);
-      if (activeToastIdRef.current !== undefined) {
-        toast.dismiss(activeToastIdRef.current);
-      }
-      activeToastIdRef.current = toast.error(title, {
+      toast.error(title, {
         description: "No se pudo cargar el estado de notificaciones.",
-        duration: TOAST_DURATION_MS,
       });
     } finally {
       setLoading(false);
     }
   };
 
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      void handleBellClick();
+    }
+  };
+
   return (
-    <button
-      type="button"
-      aria-label={isAnnouncementsMode ? "Ver notificaciones de avisos" : "Ver notificaciones"}
-      onClick={handleBellClick}
-      disabled={loading}
-      className={cn("relative h-9 w-9 inline-flex items-center justify-center rounded-full text-primary-foreground transition-colors hover:bg-primary-foreground/20", className)}
-    >
-      <Bell className="w-4 h-4 text-current" />
-      {hasNotifications && (
-        <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background" />
-      )}
-    </button>
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={isAnnouncementsMode ? "Ver notificaciones de avisos" : "Ver notificaciones"}
+          disabled={loading}
+          className={cn("relative h-9 w-9 inline-flex items-center justify-center rounded-full text-primary-foreground transition-colors hover:bg-primary-foreground/20", className)}
+        >
+          <Bell className="w-4 h-4 text-current" />
+          {hasNotifications && (
+            <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background" />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={10} className="w-[min(26rem,calc(100vw-2rem))] p-0">
+        <div className="max-h-[70vh] overflow-y-auto rounded-md bg-white p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Bell className="h-5 w-5 text-primary" />
+            <h3 className="font-semibold text-gray-900">{title}</h3>
+          </div>
+
+          <div className="space-y-3">
+            {visitUrgentNotifications.map((urgentNotification) => (
+              <div key={urgentNotification.id} className="relative rounded-xl border border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 p-2.5 shadow-[0_6px_18px_rgba(245,158,11,0.18)]">
+                <div className="mb-0.5 flex items-start justify-between gap-2 text-left">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">{urgentNotification.title}</p>
+                  </div>
+                  <AlertTriangle className="h-4 w-4 text-amber-700" />
+                </div>
+                <p className="text-xs text-gray-700 leading-tight">{urgentNotification.message}</p>
+              </div>
+            ))}
+
+            {unviewedCount > 0 ? (
+              <div className="rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+                Tienes {unviewedCount} aviso{unviewedCount === 1 ? "" : "s"} sin leer.
+              </div>
+            ) : null}
+
+            {visitUrgentNotifications.length === 0 && unviewedCount === 0 ? (
+              <p className="py-2 text-sm text-gray-500">{emptyDescription}</p>
+            ) : null}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/pages/Incidences/components/StudentIncidences.tsx
+++ b/frontend/src/pages/Incidences/components/StudentIncidences.tsx
@@ -82,7 +82,7 @@ function IncidenceNotificationCard({ notification, onDismiss }: IncidenceNotific
 }
 
 const getDismissedNotificationIds = (): string[] => {
-  if (typeof globalThis.window === "undefined") return [];
+  if (globalThis.window === undefined) return [];
   const raw = globalThis.localStorage.getItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY);
   if (!raw) return [];
 
@@ -95,12 +95,12 @@ const getDismissedNotificationIds = (): string[] => {
 };
 
 const saveDismissedNotificationIds = (ids: string[]) => {
-  if (typeof globalThis.window === "undefined") return;
+  if (globalThis.window === undefined) return;
   globalThis.localStorage.setItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY, JSON.stringify(ids));
 };
 
 const saveHomeIncidencesSeenAt = (timestamp?: string) => {
-  if (typeof globalThis.window === "undefined" || !timestamp) return;
+  if (globalThis.window === undefined || !timestamp) return;
   globalThis.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
 };
 
@@ -130,7 +130,7 @@ const mergeAndSortNotifications = (
 };
 
 const getActiveVisitUrgentNotifications = (storageKey: string | null): IncidenceNotification[] => {
-  if (typeof globalThis.window === "undefined" || !storageKey) return [];
+  if (globalThis.window === undefined || !storageKey) return [];
 
   const raw = globalThis.localStorage.getItem(storageKey);
   if (!raw) return [];

--- a/frontend/src/pages/Incidences/components/StudentIncidences.tsx
+++ b/frontend/src/pages/Incidences/components/StudentIncidences.tsx
@@ -45,9 +45,45 @@ type VisitUrgentSharedNotification = {
   source: "visitors";
 };
 
+interface IncidenceNotificationCardProps {
+  readonly notification: IncidenceNotification;
+  readonly onDismiss: (notificationId: string) => void;
+}
+
+function IncidenceNotificationCard({ notification, onDismiss }: IncidenceNotificationCardProps) {
+  const isVisitUrgent = notification.kind === "visit_limit_warning";
+
+  return (
+    <div
+      className={`relative rounded-xl border p-3 ${isVisitUrgent
+        ? "border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 shadow-[0_6px_18px_rgba(245,158,11,0.18)]"
+        : "border-red-200 bg-red-50"
+      }`}
+    >
+      {isVisitUrgent ? null : (
+        <button
+          type="button"
+          aria-label="Descartar notificación"
+          className="absolute right-2 top-2 h-8 w-8 rounded-lg text-slate-400 transition-all hover:bg-red-50 hover:text-red-600"
+          onClick={() => onDismiss(notification.id)}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+
+      <div className="mb-0.5 flex items-start justify-between gap-2 pr-8 text-left">
+        <p className="text-sm font-semibold text-gray-900">{notification.title}</p>
+        <span className="text-[11px] text-gray-400">{formatNotificationTime(notification.created_at)}</span>
+      </div>
+
+      <p className="text-xs text-gray-600 text-left">{notification.message}</p>
+    </div>
+  );
+}
+
 const getDismissedNotificationIds = (): string[] => {
-  if (typeof window === "undefined") return [];
-  const raw = window.localStorage.getItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY);
+  if (typeof globalThis.window === "undefined") return [];
+  const raw = globalThis.localStorage.getItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY);
   if (!raw) return [];
 
   try {
@@ -59,13 +95,13 @@ const getDismissedNotificationIds = (): string[] => {
 };
 
 const saveDismissedNotificationIds = (ids: string[]) => {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY, JSON.stringify(ids));
+  if (typeof globalThis.window === "undefined") return;
+  globalThis.localStorage.setItem(INCIDENCE_NOTIFICATIONS_DISMISSED_KEY, JSON.stringify(ids));
 };
 
 const saveHomeIncidencesSeenAt = (timestamp?: string) => {
-  if (typeof window === "undefined" || !timestamp) return;
-  window.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
+  if (typeof globalThis.window === "undefined" || !timestamp) return;
+  globalThis.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
 };
 
 const buildVisitUrgentNotificationStorageKey = (email: string): string | null => {
@@ -94,9 +130,9 @@ const mergeAndSortNotifications = (
 };
 
 const getActiveVisitUrgentNotifications = (storageKey: string | null): IncidenceNotification[] => {
-  if (typeof window === "undefined" || !storageKey) return [];
+  if (typeof globalThis.window === "undefined" || !storageKey) return [];
 
-  const raw = window.localStorage.getItem(storageKey);
+  const raw = globalThis.localStorage.getItem(storageKey);
   if (!raw) return [];
 
   try {
@@ -111,14 +147,15 @@ const getActiveVisitUrgentNotifications = (storageKey: string | null): Incidence
 
     if (active.length !== items.length) {
       if (active.length === 0) {
-        window.localStorage.removeItem(storageKey);
+        globalThis.localStorage.removeItem(storageKey);
       } else {
-        window.localStorage.setItem(storageKey, JSON.stringify(active));
+        globalThis.localStorage.setItem(storageKey, JSON.stringify(active));
       }
     }
 
-    return active
-      .sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at))
+    const sortedActive = [...active].sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at));
+
+    return sortedActive
       .map((item) => ({
         id: item.id,
         kind: "visit_limit_warning",
@@ -127,7 +164,7 @@ const getActiveVisitUrgentNotifications = (storageKey: string | null): Incidence
         created_at: item.created_at,
       }));
   } catch {
-    window.localStorage.removeItem(storageKey);
+    globalThis.localStorage.removeItem(storageKey);
     return [];
   }
 };
@@ -162,6 +199,20 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
     dismissedNotificationIdsRef.current = next;
     saveDismissedNotificationIds(next);
   }, []);
+
+  const recalculateUnreadNotifications = useCallback((items: IncidenceNotification[]) => {
+    const lastReadAt = getLastReadNotificationsAt();
+    setUnreadNotifications(items.filter((item) => Date.parse(item.created_at) > lastReadAt).length);
+  }, []);
+
+  const dismissNotification = useCallback((notificationId: string) => {
+    appendDismissedNotificationIds([notificationId]);
+    setNotifications((prev) => {
+      const next = prev.filter((item) => item.id !== notificationId);
+      recalculateUnreadNotifications(next);
+      return next;
+    });
+  }, [appendDismissedNotificationIds, recalculateUnreadNotifications]);
 
   useEffect(() => {
     authService.me()
@@ -210,6 +261,13 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
     }
   }, [visitUrgentStorageKey]);
 
+  const handleNotificationsOpenChange = useCallback((open: boolean) => {
+    setIsNotificationsOpen(open);
+    if (open) {
+      loadNotifications(true);
+    }
+  }, [loadNotifications]);
+
   const loadIncidences = useCallback(async (silent = false) => {
     try {
       if (!silent) setLoading(true);
@@ -257,7 +315,7 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
       <header className={UI_CLASSES.header}>
         <h1 className={UI_CLASSES.headerTitle}>Incidencias</h1>
         <div className="flex items-center gap-2">
-          <Popover open={isNotificationsOpen} onOpenChange={(open) => { setIsNotificationsOpen(open); if (open) loadNotifications(true); }}>
+          <Popover open={isNotificationsOpen} onOpenChange={handleNotificationsOpenChange}>
             <PopoverTrigger asChild>
               <Button type="button" size="icon" variant="ghost" className={`${UI_CLASSES.topIconButton} hover:scale-100`} aria-label="Notificaciones">
                 <Bell className="w-5 h-5" />
@@ -275,45 +333,15 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
                 </div>
 
                 <div className="space-y-3">
-                  {notifications.length > 0 ? notifications.map((n) => {
-                    const isVisitUrgent = n.kind === "visit_limit_warning";
-
-                    return (
-                      <div
-                        key={n.id}
-                        className={`relative rounded-xl border p-3 ${isVisitUrgent
-                          ? "border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 shadow-[0_6px_18px_rgba(245,158,11,0.18)]"
-                          : "border-red-200 bg-red-50"
-                        }`}
-                      >
-                        {!isVisitUrgent ? (
-                          <button
-                            type="button"
-                            aria-label="Descartar notificación"
-                            className="absolute right-2 top-2 h-8 w-8 rounded-lg text-slate-400 transition-all hover:bg-red-50 hover:text-red-600"
-                            onClick={() => {
-                              appendDismissedNotificationIds([n.id]);
-                              setNotifications((prev) => {
-                                const next = prev.filter((item) => item.id !== n.id);
-                                const lastReadAt = getLastReadNotificationsAt();
-                                setUnreadNotifications(next.filter((item) => Date.parse(item.created_at) > lastReadAt).length);
-                                return next;
-                              });
-                            }}
-                          >
-                            <X className="h-4 w-4" />
-                          </button>
-                        ) : null}
-
-                        <div className="mb-0.5 flex items-start justify-between gap-2 pr-8 text-left">
-                          <p className="text-sm font-semibold text-gray-900">{n.title}</p>
-                          <span className="text-[11px] text-gray-400">{formatNotificationTime(n.created_at)}</span>
-                        </div>
-
-                        <p className="text-xs text-gray-600 text-left">{n.message}</p>
-                      </div>
-                    );
-                  }) : <p className="py-4 text-sm text-gray-500 text-center">Sin notificaciones</p>}
+                  {notifications.length > 0
+                    ? notifications.map((notification) => (
+                        <IncidenceNotificationCard
+                          key={notification.id}
+                          notification={notification}
+                          onDismiss={dismissNotification}
+                        />
+                      ))
+                    : <p className="py-4 text-sm text-gray-500 text-center">Sin notificaciones</p>}
                 </div>
               </div>
             </PopoverContent>

--- a/frontend/src/pages/Incidences/components/StudentIncidences.tsx
+++ b/frontend/src/pages/Incidences/components/StudentIncidences.tsx
@@ -32,7 +32,17 @@ type IncidenceNotification = {
 
 const INCIDENCE_NOTIFICATIONS_DISMISSED_KEY = "incidences-notifications-dismissed-ids";
 const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
+const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
 const LIVE_REFRESH_MS = 3000;
+
+type VisitUrgentSharedNotification = {
+  id: string;
+  title: string;
+  message: string;
+  created_at: string;
+  expires_at: string;
+  source: "visitors";
+};
 
 const getDismissedNotificationIds = (): string[] => {
   if (typeof window === "undefined") return [];
@@ -55,6 +65,62 @@ const saveDismissedNotificationIds = (ids: string[]) => {
 const saveHomeIncidencesSeenAt = (timestamp?: string) => {
   if (typeof window === "undefined" || !timestamp) return;
   window.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
+};
+
+const mergeAndSortNotifications = (
+  baseItems: IncidenceNotification[],
+  urgentItems: IncidenceNotification[],
+  dismissedIds: string[]
+): IncidenceNotification[] => {
+  return [...urgentItems, ...baseItems]
+    .filter((item) => item.kind === "visit_limit_warning" || !dismissedIds.includes(item.id))
+    .sort((a, b) => {
+      const aPinned = a.kind === "visit_limit_warning" ? 1 : 0;
+      const bPinned = b.kind === "visit_limit_warning" ? 1 : 0;
+      if (aPinned !== bPinned) {
+        return bPinned - aPinned;
+      }
+      return Date.parse(b.created_at) - Date.parse(a.created_at);
+    });
+};
+
+const getActiveVisitUrgentNotifications = (): IncidenceNotification[] => {
+  if (typeof window === "undefined") return [];
+
+  const raw = window.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as VisitUrgentSharedNotification | VisitUrgentSharedNotification[];
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    const nowMs = Date.now();
+
+    const active = items.filter((item) => {
+      const expiresAtMs = Date.parse(item.expires_at);
+      return Number.isFinite(expiresAtMs) && expiresAtMs > nowMs;
+    });
+
+    if (active.length !== items.length) {
+      if (active.length === 0) {
+        window.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+      } else {
+        window.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+      }
+    }
+
+    return active
+      .sort((a, b) => Date.parse(a.expires_at) - Date.parse(b.expires_at))
+      .map((item) => ({
+        id: item.id,
+        kind: "visit_limit_warning",
+        title: item.title,
+        message: item.message,
+        created_at: item.created_at,
+      }));
+  } catch {
+    window.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+    return [];
+  }
 };
 
 export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIncidencesProps) {
@@ -91,12 +157,21 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
       if (!silent) setNotificationsLoading(true);
       const res = await fetchWithAuth(`${API_URL_INCIDENCES}notifications/`);
       if (!res.ok) return;
+
       const data = await res.json();
-      const all = Array.isArray(data.results) ? (data.results as IncidenceNotification[]) : [];
-      if (all.length > 0) {
-        saveHomeIncidencesSeenAt(all[0].created_at);
+      const baseItems = Array.isArray(data.results) ? (data.results as IncidenceNotification[]) : [];
+      const visitWarnings = getActiveVisitUrgentNotifications();
+
+      if (markAsRead && baseItems.length > 0) {
+        saveHomeIncidencesSeenAt(baseItems[0].created_at);
       }
-      const latestNotifications = all.filter((n) => !dismissedNotificationIdsRef.current.includes(n.id));
+
+      const latestNotifications = mergeAndSortNotifications(
+        baseItems,
+        visitWarnings,
+        dismissedNotificationIdsRef.current
+      );
+
       const lastReadAt = getLastReadNotificationsAt();
 
       if (markAsRead && latestNotifications.length > 0) {
@@ -107,7 +182,11 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
         setUnreadNotifications(count);
       }
       setNotifications(latestNotifications);
-    } catch (e) { console.error(e); } finally { if (!silent) setNotificationsLoading(false); }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      if (!silent) setNotificationsLoading(false);
+    }
   }, []);
 
   const loadIncidences = useCallback(async (silent = false) => {
@@ -175,31 +254,45 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
                 </div>
 
                 <div className="space-y-3">
-                  {notifications.length > 0 ? notifications.map((n) => (
-                    <div key={n.id} className="relative rounded-xl border border-red-200 bg-red-50 p-3">
-                      <button
-                        type="button"
-                        aria-label="Descartar notificación"
-                        className="absolute right-2 top-2 h-8 w-8 rounded-lg text-slate-400 transition-all hover:bg-red-50 hover:text-red-600"
-                        onClick={() => {
-                          appendDismissedNotificationIds([n.id]);
-                          setNotifications((prev) => {
-                            const next = prev.filter((item) => item.id !== n.id);
-                            const lastReadAt = getLastReadNotificationsAt();
-                            setUnreadNotifications(next.filter((item) => Date.parse(item.created_at) > lastReadAt).length);
-                            return next;
-                          });
-                        }}
+                  {notifications.length > 0 ? notifications.map((n) => {
+                    const isVisitUrgent = n.kind === "visit_limit_warning";
+
+                    return (
+                      <div
+                        key={n.id}
+                        className={`relative rounded-xl border p-3 ${isVisitUrgent
+                          ? "border-amber-300 bg-gradient-to-r from-amber-50 to-orange-50 shadow-[0_6px_18px_rgba(245,158,11,0.18)]"
+                          : "border-red-200 bg-red-50"
+                        }`}
                       >
-                        <X className="h-4 w-4" />
-                      </button>
-                      <div className="mb-1 flex items-start justify-between gap-2 pr-9 text-left">
-                        <p className="text-sm font-semibold text-gray-900">{n.title}</p>
-                        <span className="text-[11px] text-gray-400">{formatNotificationTime(n.created_at)}</span>
+                        {!isVisitUrgent ? (
+                          <button
+                            type="button"
+                            aria-label="Descartar notificación"
+                            className="absolute right-2 top-2 h-8 w-8 rounded-lg text-slate-400 transition-all hover:bg-red-50 hover:text-red-600"
+                            onClick={() => {
+                              appendDismissedNotificationIds([n.id]);
+                              setNotifications((prev) => {
+                                const next = prev.filter((item) => item.id !== n.id);
+                                const lastReadAt = getLastReadNotificationsAt();
+                                setUnreadNotifications(next.filter((item) => Date.parse(item.created_at) > lastReadAt).length);
+                                return next;
+                              });
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </button>
+                        ) : null}
+
+                        <div className="mb-0.5 flex items-start justify-between gap-2 pr-8 text-left">
+                          <p className="text-sm font-semibold text-gray-900">{n.title}</p>
+                          <span className="text-[11px] text-gray-400">{formatNotificationTime(n.created_at)}</span>
+                        </div>
+
+                        <p className="text-xs text-gray-600 text-left">{n.message}</p>
                       </div>
-                      <p className="text-xs text-gray-600 text-left">{n.message}</p>
-                    </div>
-                  )) : <p className="py-4 text-sm text-gray-500 text-center">Sin notificaciones</p>}
+                    );
+                  }) : <p className="py-4 text-sm text-gray-500 text-center">Sin notificaciones</p>}
                 </div>
               </div>
             </PopoverContent>

--- a/frontend/src/pages/Incidences/components/StudentIncidences.tsx
+++ b/frontend/src/pages/Incidences/components/StudentIncidences.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "../../../components/ui/card";
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from "../../../components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "../../../components/ui/popover";
 import { fetchWithAuth, API_URL_INCIDENCES } from "../../../utils/api";
+import { authService } from "../../../services/auth";
 import { IncidenceForm } from "./IncidenceForm";
 import { IncidenceService } from "../../../services/incidences";
 
@@ -32,7 +33,7 @@ type IncidenceNotification = {
 
 const INCIDENCE_NOTIFICATIONS_DISMISSED_KEY = "incidences-notifications-dismissed-ids";
 const HOME_INCIDENCES_SEEN_AT_KEY = "home-incidences-seen-at";
-const VISIT_URGENT_NOTIFICATION_KEY = "visit-urgent-shared-notifications";
+const VISIT_URGENT_NOTIFICATION_KEY_BASE = "visit-urgent-shared-notifications";
 const LIVE_REFRESH_MS = 3000;
 
 type VisitUrgentSharedNotification = {
@@ -67,6 +68,14 @@ const saveHomeIncidencesSeenAt = (timestamp?: string) => {
   window.localStorage.setItem(HOME_INCIDENCES_SEEN_AT_KEY, timestamp);
 };
 
+const buildVisitUrgentNotificationStorageKey = (email: string): string | null => {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return `${VISIT_URGENT_NOTIFICATION_KEY_BASE}:${normalized}`;
+};
+
 const mergeAndSortNotifications = (
   baseItems: IncidenceNotification[],
   urgentItems: IncidenceNotification[],
@@ -84,10 +93,10 @@ const mergeAndSortNotifications = (
     });
 };
 
-const getActiveVisitUrgentNotifications = (): IncidenceNotification[] => {
-  if (typeof window === "undefined") return [];
+const getActiveVisitUrgentNotifications = (storageKey: string | null): IncidenceNotification[] => {
+  if (typeof window === "undefined" || !storageKey) return [];
 
-  const raw = window.localStorage.getItem(VISIT_URGENT_NOTIFICATION_KEY);
+  const raw = window.localStorage.getItem(storageKey);
   if (!raw) return [];
 
   try {
@@ -102,9 +111,9 @@ const getActiveVisitUrgentNotifications = (): IncidenceNotification[] => {
 
     if (active.length !== items.length) {
       if (active.length === 0) {
-        window.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+        window.localStorage.removeItem(storageKey);
       } else {
-        window.localStorage.setItem(VISIT_URGENT_NOTIFICATION_KEY, JSON.stringify(active));
+        window.localStorage.setItem(storageKey, JSON.stringify(active));
       }
     }
 
@@ -118,7 +127,7 @@ const getActiveVisitUrgentNotifications = (): IncidenceNotification[] => {
         created_at: item.created_at,
       }));
   } catch {
-    window.localStorage.removeItem(VISIT_URGENT_NOTIFICATION_KEY);
+    window.localStorage.removeItem(storageKey);
     return [];
   }
 };
@@ -133,7 +142,9 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
   const [notificationsLoading, setNotificationsLoading] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [currentUserEmail, setCurrentUserEmail] = useState("");
   const dismissedNotificationIdsRef = useRef<string[]>(getDismissedNotificationIds());
+  const visitUrgentStorageKey = buildVisitUrgentNotificationStorageKey(currentUserEmail);
 
   const [incidenceToDelete, setIncidenceToDelete] = useState<BaseIncidence | null>(null);
   const [incidenceToEdit, setIncidenceToEdit] = useState<BaseIncidence | null>(null);
@@ -152,6 +163,16 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
     saveDismissedNotificationIds(next);
   }, []);
 
+  useEffect(() => {
+    authService.me()
+      .then((session) => {
+        setCurrentUserEmail((session.user?.email || "").trim().toLowerCase());
+      })
+      .catch(() => {
+        setCurrentUserEmail("");
+      });
+  }, []);
+
   const loadNotifications = useCallback(async (markAsRead = false, silent = false) => {
     try {
       if (!silent) setNotificationsLoading(true);
@@ -160,7 +181,7 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
 
       const data = await res.json();
       const baseItems = Array.isArray(data.results) ? (data.results as IncidenceNotification[]) : [];
-      const visitWarnings = getActiveVisitUrgentNotifications();
+      const visitWarnings = getActiveVisitUrgentNotifications(visitUrgentStorageKey);
 
       if (markAsRead && baseItems.length > 0) {
         saveHomeIncidencesSeenAt(baseItems[0].created_at);
@@ -187,7 +208,7 @@ export default function StudentIncidences({ onGoToProfile, onLogout }: StudentIn
     } finally {
       if (!silent) setNotificationsLoading(false);
     }
-  }, []);
+  }, [visitUrgentStorageKey]);
 
   const loadIncidences = useCallback(async (silent = false) => {
     try {

--- a/frontend/src/pages/Visitors/ActiveGuestPasses.tsx
+++ b/frontend/src/pages/Visitors/ActiveGuestPasses.tsx
@@ -25,6 +25,7 @@ import {
 const DEFAULT_MAX_DURATION_HOURS = 24;
 const DEFAULT_MAX_CONCURRENT_PASSES = 3;
 const TIME_SLOT_INTERVAL_MINUTES = 30;
+const VISIT_STATE_CHANGED_EVENT = "visit-state-changed";
 
 type GuestPassFormState = {
   guest_first_name: string;
@@ -867,7 +868,8 @@ async function submitGuestPass({
       description: `Código asignado: ${created.pass_code}`,
     });
     setForm(buildInitialFormState());
-    await loadPasses();
+    globalThis.dispatchEvent(new Event(VISIT_STATE_CHANGED_EVENT));
+      await loadPasses();
   } catch (unknownError) {
     handleCreateError(unknownError, setFormErrors);
   } finally {
@@ -936,6 +938,7 @@ export function ActiveGuestPassesPage({ onGoToProfile, onLogout }: ActiveGuestPa
     try {
       await cancelMyGuestPass(pass.id);
       toast.success("Pase cancelado correctamente.");
+      globalThis.dispatchEvent(new Event(VISIT_STATE_CHANGED_EVENT));
       await loadPasses();
     } catch (unknownError) {
       const message =

--- a/frontend/src/pages/Visitors/AdminGuestPassList.tsx
+++ b/frontend/src/pages/Visitors/AdminGuestPassList.tsx
@@ -229,7 +229,7 @@ export function AdminGuestPassListPage() {
       ) : processedPasses.length === 0 ? (
         <Card className="border-dashed shadow-none bg-gray-50/50">
           <CardContent className="py-12 text-center">
-            <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan.</p>
+            <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan</p>
           </CardContent>
         </Card>
       ) : (

--- a/frontend/src/pages/Visitors/AdminGuestPassList.tsx
+++ b/frontend/src/pages/Visitors/AdminGuestPassList.tsx
@@ -167,75 +167,82 @@ export function AdminGuestPassListPage() {
       }
     });
 
-  const content = loading ? (
-    <div className="flex flex-col items-center justify-center py-20 gap-3">
-      <RefreshCw className="w-8 h-8 text-purple-500 animate-spin" />
-      <p className="text-sm text-gray-500 font-medium">Cargando pases de invitados...</p>
-    </div>
-  ) : processedPasses.length === 0 ? (
-    <Card className="border-dashed shadow-none bg-gray-50/50">
-      <CardContent className="py-12 text-center">
-        <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan</p>
-      </CardContent>
-    </Card>
-  ) : (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {processedPasses.map((pass) => (
-        <Card
-          key={pass.id}
-          className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
-          role="button"
-          tabIndex={0}
-          aria-label={pass.full_name}
-          onClick={() => setSelectedPass(pass)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              setSelectedPass(pass);
-            }
-          }}
-        >
-          <CardContent className="p-5 flex flex-col h-full">
-            <div className="flex items-start justify-between gap-2 mb-3">
-              <span className="font-bold text-gray-900 group-hover:text-purple-700 transition-colors line-clamp-1 flex-1">
-                {pass.full_name}
-              </span>
-              <Badge className={`${STATUS_BADGE[pass.status ?? ""]} whitespace-nowrap shrink-0`}>
-                {STATUS_LABEL[pass.status ?? ""] ?? pass.status}
-              </Badge>
-            </div>
-
-            <div className="space-y-2 flex-1">
-              <div className="flex items-center gap-2 text-xs">
-                <User className="w-3.5 h-3.5 text-gray-400" />
-                <span className="text-gray-500">De: </span>
-                <span className="font-semibold text-gray-800 line-clamp-1">{pass.resident_name}</span>
+  let content;
+  if (loading) {
+    content = (
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <RefreshCw className="w-8 h-8 text-purple-500 animate-spin" />
+        <p className="text-sm text-gray-500 font-medium">Cargando pases de invitados...</p>
+      </div>
+    );
+  } else if (processedPasses.length === 0) {
+    content = (
+      <Card className="border-dashed shadow-none bg-gray-50/50">
+        <CardContent className="py-12 text-center">
+          <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan</p>
+        </CardContent>
+      </Card>
+    );
+  } else {
+    content = (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {processedPasses.map((pass) => (
+          <Card
+            key={pass.id}
+            className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
+            role="button"
+            tabIndex={0}
+            aria-label={pass.full_name}
+            onClick={() => setSelectedPass(pass)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setSelectedPass(pass);
+              }
+            }}
+          >
+            <CardContent className="p-5 flex flex-col h-full">
+              <div className="flex items-start justify-between gap-2 mb-3">
+                <span className="font-bold text-gray-900 group-hover:text-purple-700 transition-colors line-clamp-1 flex-1">
+                  {pass.full_name}
+                </span>
+                <Badge className={`${STATUS_BADGE[pass.status ?? ""]} whitespace-nowrap shrink-0`}>
+                  {STATUS_LABEL[pass.status ?? ""] ?? pass.status}
+                </Badge>
               </div>
 
-              <div className="flex items-center gap-2 text-xs">
-                <Hash className="w-3.5 h-3.5 text-gray-400" />
-                <span className="text-gray-500">Código: </span>
-                <span className="font-mono font-bold text-purple-600">{pass.pass_code}</span>
-              </div>
+              <div className="space-y-2 flex-1">
+                <div className="flex items-center gap-2 text-xs">
+                  <User className="w-3.5 h-3.5 text-gray-400" />
+                  <span className="text-gray-500">De: </span>
+                  <span className="font-semibold text-gray-800 line-clamp-1">{pass.resident_name}</span>
+                </div>
 
-              <div className="flex items-start gap-2 text-[11px] text-gray-500 bg-gray-50 p-2 rounded-md border border-gray-100 mt-2">
-                <Calendar className="w-3.5 h-3.5 text-gray-400 shrink-0" />
-                <div className="leading-tight">
-                  <p>{formatDateTime(pass.valid_from).split(',')[0]}</p>
-                  <p className="text-[10px] text-gray-400">hasta {formatDateTime(pass.valid_until).split(',')[0]}</p>
+                <div className="flex items-center gap-2 text-xs">
+                  <Hash className="w-3.5 h-3.5 text-gray-400" />
+                  <span className="text-gray-500">Código: </span>
+                  <span className="font-mono font-bold text-purple-600">{pass.pass_code}</span>
+                </div>
+
+                <div className="flex items-start gap-2 text-[11px] text-gray-500 bg-gray-50 p-2 rounded-md border border-gray-100 mt-2">
+                  <Calendar className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                  <div className="leading-tight">
+                    <p>{formatDateTime(pass.valid_from).split(',')[0]}</p>
+                    <p className="text-[10px] text-gray-400">hasta {formatDateTime(pass.valid_until).split(',')[0]}</p>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between text-[10px] text-gray-400 font-medium">
-              <span className="uppercase tracking-wider">Creado</span>
-              <span>{formatDateTime(pass.created_at).split(',')[0]}</span>
-            </div>
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-  );
+              <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between text-[10px] text-gray-400 font-medium">
+                <span className="uppercase tracking-wider">Creado</span>
+                <span>{formatDateTime(pass.created_at).split(',')[0]}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/Visitors/AdminGuestPassList.tsx
+++ b/frontend/src/pages/Visitors/AdminGuestPassList.tsx
@@ -238,7 +238,16 @@ export function AdminGuestPassListPage() {
             <Card
               key={pass.id}
               className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
+              role="button"
+              tabIndex={0}
+              aria-label={pass.full_name}
               onClick={() => setSelectedPass(pass)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  setSelectedPass(pass);
+                }
+              }}
             >
               <CardContent className="p-5 flex flex-col h-full">
                 <div className="flex items-start justify-between gap-2 mb-3">

--- a/frontend/src/pages/Visitors/AdminGuestPassList.tsx
+++ b/frontend/src/pages/Visitors/AdminGuestPassList.tsx
@@ -167,6 +167,76 @@ export function AdminGuestPassListPage() {
       }
     });
 
+  const content = loading ? (
+    <div className="flex flex-col items-center justify-center py-20 gap-3">
+      <RefreshCw className="w-8 h-8 text-purple-500 animate-spin" />
+      <p className="text-sm text-gray-500 font-medium">Cargando pases de invitados...</p>
+    </div>
+  ) : processedPasses.length === 0 ? (
+    <Card className="border-dashed shadow-none bg-gray-50/50">
+      <CardContent className="py-12 text-center">
+        <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan</p>
+      </CardContent>
+    </Card>
+  ) : (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {processedPasses.map((pass) => (
+        <Card
+          key={pass.id}
+          className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
+          role="button"
+          tabIndex={0}
+          aria-label={pass.full_name}
+          onClick={() => setSelectedPass(pass)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              setSelectedPass(pass);
+            }
+          }}
+        >
+          <CardContent className="p-5 flex flex-col h-full">
+            <div className="flex items-start justify-between gap-2 mb-3">
+              <span className="font-bold text-gray-900 group-hover:text-purple-700 transition-colors line-clamp-1 flex-1">
+                {pass.full_name}
+              </span>
+              <Badge className={`${STATUS_BADGE[pass.status ?? ""]} whitespace-nowrap shrink-0`}>
+                {STATUS_LABEL[pass.status ?? ""] ?? pass.status}
+              </Badge>
+            </div>
+
+            <div className="space-y-2 flex-1">
+              <div className="flex items-center gap-2 text-xs">
+                <User className="w-3.5 h-3.5 text-gray-400" />
+                <span className="text-gray-500">De: </span>
+                <span className="font-semibold text-gray-800 line-clamp-1">{pass.resident_name}</span>
+              </div>
+
+              <div className="flex items-center gap-2 text-xs">
+                <Hash className="w-3.5 h-3.5 text-gray-400" />
+                <span className="text-gray-500">Código: </span>
+                <span className="font-mono font-bold text-purple-600">{pass.pass_code}</span>
+              </div>
+
+              <div className="flex items-start gap-2 text-[11px] text-gray-500 bg-gray-50 p-2 rounded-md border border-gray-100 mt-2">
+                <Calendar className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                <div className="leading-tight">
+                  <p>{formatDateTime(pass.valid_from).split(',')[0]}</p>
+                  <p className="text-[10px] text-gray-400">hasta {formatDateTime(pass.valid_until).split(',')[0]}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between text-[10px] text-gray-400 font-medium">
+              <span className="uppercase tracking-wider">Creado</span>
+              <span>{formatDateTime(pass.created_at).split(',')[0]}</span>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
@@ -221,75 +291,7 @@ export function AdminGuestPassListPage() {
         </div>
       </div>
 
-      {loading ? (
-        <div className="flex flex-col items-center justify-center py-20 gap-3">
-          <RefreshCw className="w-8 h-8 text-purple-500 animate-spin" />
-          <p className="text-sm text-gray-500 font-medium">Cargando pases de invitados...</p>
-        </div>
-      ) : processedPasses.length === 0 ? (
-        <Card className="border-dashed shadow-none bg-gray-50/50">
-          <CardContent className="py-12 text-center">
-            <p className="text-gray-500 font-medium">No se han encontrado pases que coincidan</p>
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {processedPasses.map((pass) => (
-            <Card
-              key={pass.id}
-              className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
-              role="button"
-              tabIndex={0}
-              aria-label={pass.full_name}
-              onClick={() => setSelectedPass(pass)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  event.preventDefault();
-                  setSelectedPass(pass);
-                }
-              }}
-            >
-              <CardContent className="p-5 flex flex-col h-full">
-                <div className="flex items-start justify-between gap-2 mb-3">
-                  <span className="font-bold text-gray-900 group-hover:text-purple-700 transition-colors line-clamp-1 flex-1">
-                    {pass.full_name}
-                  </span>
-                  <Badge className={`${STATUS_BADGE[pass.status ?? ""]} whitespace-nowrap shrink-0`}>
-                    {STATUS_LABEL[pass.status ?? ""] ?? pass.status}
-                  </Badge>
-                </div>
-                
-                <div className="space-y-2 flex-1">
-                  <div className="flex items-center gap-2 text-xs">
-                    <User className="w-3.5 h-3.5 text-gray-400" />
-                    <span className="text-gray-500">De: </span>
-                    <span className="font-semibold text-gray-800 line-clamp-1">{pass.resident_name}</span>
-                  </div>
-                  
-                  <div className="flex items-center gap-2 text-xs">
-                    <Hash className="w-3.5 h-3.5 text-gray-400" />
-                    <span className="text-gray-500">Código: </span>
-                    <span className="font-mono font-bold text-purple-600">{pass.pass_code}</span>
-                  </div>
-
-                  <div className="flex items-start gap-2 text-[11px] text-gray-500 bg-gray-50 p-2 rounded-md border border-gray-100 mt-2">
-                    <Calendar className="w-3.5 h-3.5 text-gray-400 shrink-0" />
-                    <div className="leading-tight">
-                      <p>{formatDateTime(pass.valid_from).split(',')[0]}</p>
-                      <p className="text-[10px] text-gray-400">hasta {formatDateTime(pass.valid_until).split(',')[0]}</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between text-[10px] text-gray-400 font-medium">
-                  <span className="uppercase tracking-wider">Creado</span>
-                  <span>{formatDateTime(pass.created_at).split(',')[0]}</span>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      )}
+      {content}
 
       <GuestPassDetailDialog pass={selectedPass} onClose={() => setSelectedPass(null)} />
     </div>

--- a/frontend/src/pages/Visitors/__tests__/AdminGuestPassList.test.tsx
+++ b/frontend/src/pages/Visitors/__tests__/AdminGuestPassList.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
 import { AdminGuestPassListPage } from '../AdminGuestPassList'
 
 vi.mock('../../../services/guestPasses', () => ({
@@ -80,7 +81,7 @@ describe('AdminGuestPassListPage — [NX-S2.39 / NX-S2.40]', () => {
 
     await user.type(screen.getByPlaceholderText(/Buscar/), 'xyz-inexistente')
 
-    expect(screen.getByText('No hay pases que coincidan.')).toBeInTheDocument()
+    expect(screen.getByText('No se han encontrado pases que coincidan')).toBeInTheDocument()
   })
 
   it('abre el diálogo de detalle al hacer clic en un pase', async () => {
@@ -114,10 +115,16 @@ describe('AdminGuestPassListPage — [NX-S2.39 / NX-S2.40]', () => {
   })
 
   it('muestra el comentario del pase cuando existe', async () => {
+    const user = userEvent.setup()
     render(<AdminGuestPassListPage />)
+    await waitFor(() => screen.getByText('Juan Pérez'))
+
+    const passCard = screen.getByRole('button', { name: /Juan Pérez/i })
+    await user.click(passCard)
+
     await waitFor(() => {
-      // El comentario se muestra en la tarjeta de la lista
-      expect(screen.getByText('"Visita familiar"')).toBeInTheDocument()
+      const dialog = screen.getByRole('dialog')
+      expect(within(dialog).getByText(/Visita familiar/i)).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Verificar creando un pase que caduque en <10 minutos (hacerlo desde DB para no esperar tanto) y ver que llega la notificación flotante y además hay otra notificación "contador" en las campanas de notificaciones, cuando acaban los 10 minutos la notificación se descarta sola.

Verificar que si creas otro pase, los dos salgan en las campanas como notificaciones fijas hasta que caduquen los 10 minutos.

Verificar que si la hora límite de visitas de la residencia es X, los últimos 10 minutos antes de esa hora, si hay pases de visitas activos salta una notificación fija como contadora en la aplicación que no se descarta hasta que acaba el tiempo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Notificaciones urgentes de visitas próximas sincronizadas entre pestañas y almacenadas por usuario; se priorizan y pinnean en la lista.

* **Mejoras de Interfaz**
  * Banner fijo “AVISO URGENTE DE VISITAS” con cuenta regresiva y etiqueta de fin.
  * Campana abre un popover controlado que muestra urgentes junto a anuncios; contador combinado.
  * Tarjetas urgentes con estilo distinto y sin botón de cerrar; botón de cerrar condicional para otras notificaciones.

* **Accesibilidad**
  * Tarjetas de pases admiten interacción por teclado y atributos ARIA.

* **Tests**
  * Actualizadas pruebas y e2e para reflejar el texto de estado sin resultados.

* **Otras**
  * Eventos emitidos tras crear/cancelar pases; refresco periódico (cada 30s) y deduplicación de avisos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->