### PR TITLE
feat: Notificacion a admin de visitantes fuera de horario y tests

### DIFF
--- a/backend/apps/guests/tests/test_admin_guest_pass_list.py
+++ b/backend/apps/guests/tests/test_admin_guest_pass_list.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import time, timedelta
 
 from django.contrib.auth import get_user_model
 from django.db.utils import ProgrammingError
@@ -7,11 +7,12 @@ from django_tenants.test.cases import TenantTestCase
 from django_tenants.test.client import TenantClient
 
 from apps.common.services import build_access_token
-from apps.guests.models import GuestPass
+from apps.guests.models import GuestPass, GuestPassPolicy
 from apps.membership.models import Membership, Role
 from apps.residences.models import Residence, ResidenceDomain
 
 ADMIN_LIST_URL = "/api/admin/guest-passes/"
+ADMIN_NOTIFICATIONS_URL = "/api/admin/guest-passes/notifications/"
 
 
 class AdminGuestPassListTests(TenantTestCase):
@@ -369,4 +370,48 @@ class AdminGuestPassListTests(TenantTestCase):
     def test_unauthenticated_request_is_rejected(self):
         client = TenantClient(self.tenant)
         response = client.get(ADMIN_LIST_URL)
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_gets_notifications_for_visitors_after_end_time(self):
+        now = timezone.now()
+        self._create_pass(
+            resident=self.resident_membership,
+            pass_code="NOTIF-PASS-1",
+            status=GuestPass.Status.ACTIVE,
+            valid_from=now - timedelta(hours=1),
+            valid_until=now + timedelta(hours=2),
+        )
+        GuestPassPolicy.objects.update_or_create(
+            residence=self.residence,
+            defaults={"visit_end_time": time(0, 0)},
+        )
+
+        response = self.admin_client.get(ADMIN_NOTIFICATIONS_URL)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["title"], "Visitante fuera de horario")
+        self.assertNotIn("(", payload[0]["message"])
+        self.assertNotIn(")", payload[0]["message"])
+        self.assertIn("estudiante Carlos Ruiz", payload[0]["message"])
+        self.assertNotIn("Invitado Test", payload[0]["message"])
+
+    def test_admin_notifications_empty_when_end_time_not_configured(self):
+        now = timezone.now()
+        self._create_pass(
+            resident=self.resident_membership,
+            pass_code="NOTIF-PASS-2",
+            status=GuestPass.Status.ACTIVE,
+            valid_from=now - timedelta(hours=1),
+            valid_until=now + timedelta(hours=2),
+        )
+
+        response = self.admin_client.get(ADMIN_NOTIFICATIONS_URL)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_resident_cannot_access_admin_notifications(self):
+        response = self.resident_client.get(ADMIN_NOTIFICATIONS_URL)
         self.assertEqual(response.status_code, 403)

--- a/backend/apps/guests/tests/test_admin_visitors_analytics.py
+++ b/backend/apps/guests/tests/test_admin_visitors_analytics.py
@@ -27,6 +27,7 @@ class AdminVisitorsAnalyticsTests(TenantTestCase):
         tenant.slug = "tenant-admin-visitors-analytics"
         tenant.is_active = True
         tenant.on_trial = True
+        tenant.schema_name = f"test_schema_{cls.__name__.lower()}"
 
     @classmethod
     def setup_domain(cls, domain):

--- a/backend/apps/guests/urls.py
+++ b/backend/apps/guests/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     AdminGuestPassListView,
+    AdminGuestPassNotificationsView,
     AdminGuestPassPolicyView,
     AdminGuestPassRevokeView,
     AdminVisitorsAnalyticsView,
@@ -54,6 +55,11 @@ urlpatterns = [
         "admin/guest-passes/",
         AdminGuestPassListView.as_view(),
         name="admin-guest-pass-list",
+    ),
+    path(
+        "admin/guest-passes/notifications/",
+        AdminGuestPassNotificationsView.as_view(),
+        name="admin-guest-pass-notifications",
     ),
     path(
         "admin/guest-passes/policy/",

--- a/backend/apps/guests/views.py
+++ b/backend/apps/guests/views.py
@@ -183,6 +183,56 @@ class AdminGuestPassListView(AdminGuestPassBaseView):
         return Response(serializer.data)
 
 
+class AdminGuestPassNotificationsView(AdminGuestPassBaseView):
+    NOTIFICATION_LIMIT = 8
+
+    def get(self, request):
+        residence = self._get_residence(request)
+        policy = get_or_create_guest_pass_policy(residence)
+
+        if policy.visit_end_time is None:
+            return Response([], status=status.HTTP_200_OK)
+
+        now = timezone.now()
+        current_time = timezone.localtime(now).time().replace(tzinfo=None)
+        if current_time < policy.visit_end_time:
+            return Response([], status=status.HTTP_200_OK)
+
+        guest_passes = (
+            GuestPass.objects.filter(
+                residence=residence,
+                status=GuestPass.Status.ACTIVE,
+                cancelled_at__isnull=True,
+                revoked_at__isnull=True,
+                valid_from__lte=now,
+                valid_until__gte=now,
+            )
+            .select_related("resident__user")
+            .order_by("valid_until", "-created_at")[: self.NOTIFICATION_LIMIT]
+        )
+
+        data = []
+        for guest_pass in guest_passes:
+            resident_user = getattr(getattr(guest_pass, "resident", None), "user", None)
+            resident_name = (
+                resident_user.get_full_name() if resident_user else ""
+            ) or (resident_user.email if resident_user else "un residente")
+
+            data.append(
+                {
+                    "id": guest_pass.id,
+                    "title": "Visitante fuera de horario",
+                    "message": (
+                        f"El invitado del estudiante {resident_name} está fuera de horario."
+                    ),
+                    "created_at": guest_pass.updated_at.isoformat(),
+                    "end_time": guest_pass.valid_until.isoformat(),
+                }
+            )
+
+        return Response(data, status=status.HTTP_200_OK)
+
+
 class AdminGuestPassPolicyView(AdminGuestPassBaseView):
     def get(self, request):
         policy = get_or_create_guest_pass_policy(self._get_residence(request))

--- a/frontend/e2e/helpers/mockApi.ts
+++ b/frontend/e2e/helpers/mockApi.ts
@@ -101,6 +101,8 @@ export async function mockAdminApi(page: Page, overrides: {
       await route.fulfill(json(guestPasses))
     } else if (path === '/api/admin/guest-passes/policy/') {
       await route.fulfill(json({ max_duration_hours: 24, max_concurrent_passes: 3 }))
+    } else if (path === '/api/admin/guest-passes/notifications/') {
+      await route.fulfill(json([]))
     } else if (path === '/api/chats/groups/') {
       await route.fulfill(json([]))
     } else if (path.startsWith('/api/announcements/')) {

--- a/frontend/src/components/AdminView.tsx
+++ b/frontend/src/components/AdminView.tsx
@@ -97,6 +97,7 @@ const getCardClassesBySource = (source: AdminNotificationSource) => {
     if (source === "incidences") return "bg-red-50 border-red-200";
     if (source === "announcements") return "bg-blue-50 border-blue-200";
     if (source === "events") return "bg-yellow-50 border-yellow-200";
+    if (source === "visitors") return "bg-amber-50 border-amber-200";
     return "bg-green-50 border-green-200";
 };
 
@@ -104,6 +105,7 @@ const getTabByNotificationSource = (source: AdminNotificationSource): AdminTab =
     if (source === "incidences") return "incidences";
     if (source === "announcements") return "announcements";
     if (source === "events") return "events";
+    if (source === "visitors") return "visitors";
     return "reservations";
 };
 
@@ -660,6 +662,7 @@ export function AdminView({ onLogout, currentUser }: AdminViewProps) {
                                         ) : (
                                             notifications.map((notification) => {
                                                 const isSeen = seenNotificationIds.includes(notification.id);
+                                                const canDismiss = notification.source !== "visitors";
 
                                                 return (
                                                     <div
@@ -683,18 +686,20 @@ export function AdminView({ onLogout, currentUser }: AdminViewProps) {
                                                             <p className="mt-2 text-[11px] text-gray-400">{formatRelativeTime(notification.timestamp)}</p>
                                                         </button>
 
-                                                        <button
-                                                            type="button"
-                                                            onClick={(event) => {
-                                                                event.stopPropagation();
-                                                                handleDismissNotification(notification);
-                                                            }}
-                                                            className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-black/5 hover:text-gray-700"
-                                                            aria-label="Descartar notificación"
-                                                            title="Descartar notificación"
-                                                        >
-                                                            <X className="h-4 w-4" />
-                                                        </button>
+                                                        {canDismiss && (
+                                                            <button
+                                                                type="button"
+                                                                onClick={(event) => {
+                                                                    event.stopPropagation();
+                                                                    handleDismissNotification(notification);
+                                                                }}
+                                                                className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-black/5 hover:text-gray-700"
+                                                                aria-label="Descartar notificación"
+                                                                title="Descartar notificación"
+                                                            >
+                                                                <X className="h-4 w-4" />
+                                                            </button>
+                                                        )}
                                                     </div>
                                                 );
                                             })

--- a/frontend/src/components/useAdminNotifications.ts
+++ b/frontend/src/components/useAdminNotifications.ts
@@ -4,7 +4,7 @@ import { authService } from "../services/auth";
 import type { AnnouncementList } from "../types/announcement.types";
 import { API_URL, API_URL_INCIDENCES, fetchWithAuth } from "../utils/api";
 
-export type AdminNotificationSource = "incidences" | "reservations" | "events" | "announcements";
+export type AdminNotificationSource = "incidences" | "reservations" | "events" | "announcements" | "visitors";
 
 export type AdminNotification = {
     id: string;
@@ -30,6 +30,14 @@ type ReservationNotificationItem = {
 };
 
 type ObjectReservationNotificationItem = {
+    id: number;
+    title: string;
+    message: string;
+    created_at: string;
+    end_time: string;
+};
+
+type VisitorNotificationItem = {
     id: number;
     title: string;
     message: string;
@@ -172,11 +180,12 @@ export function useAdminNotifications() {
                 setNotificationsLoading(true);
             }
 
-            const [announcementsResult, incidencesResult, reservationsResult, objectReservationsResult, eventsResult] = await Promise.allSettled([
+            const [announcementsResult, incidencesResult, reservationsResult, objectReservationsResult, visitorNotificationsResult, eventsResult] = await Promise.allSettled([
                 announcementService.getAnnouncements(),
                 fetchWithAuth(`${API_URL_INCIDENCES}notifications/`),
                 fetchWithAuth("/api/admin/spaces/notifications/"),
                 fetchWithAuth("/api/admin/objects/notifications/"),
+                fetchWithAuth("/api/admin/guest-passes/notifications/"),
                 fetchWithAuth(API_URL),
             ]);
 
@@ -227,6 +236,21 @@ export function useAdminNotifications() {
                         timestamp: item.created_at,
                     }))
                     .filter((item) => !dismissedReservationIds.includes(item.id))
+                    .forEach((item) => merged.push(item));
+            }
+
+            if (visitorNotificationsResult.status === "fulfilled" && visitorNotificationsResult.value.ok) {
+                const data = await visitorNotificationsResult.value.json();
+                const visitorItems = Array.isArray(data) ? (data as VisitorNotificationItem[]) : [];
+
+                visitorItems
+                    .map((item) => ({
+                        id: `visitors-${item.id}`,
+                        source: "visitors" as const,
+                        title: `[Visitantes] ${item.title}`,
+                        message: item.message,
+                        timestamp: item.created_at,
+                    }))
                     .forEach((item) => merged.push(item));
             }
 

--- a/frontend/src/pages/Visitors/AdminGuestPassList.tsx
+++ b/frontend/src/pages/Visitors/AdminGuestPassList.tsx
@@ -189,7 +189,11 @@ export function AdminGuestPassListPage() {
         {processedPasses.map((pass) => (
           <Card
             key={pass.id}
-            className="hover:shadow-md transition-all cursor-pointer hover:border-purple-300 group border-gray-200"
+            className={`hover:shadow-md transition-all cursor-pointer group ${
+              pass.out_of_schedule
+                ? "border-red-300 bg-red-50/70 hover:border-red-400"
+                : "border-gray-200 hover:border-purple-300"
+            }`}
             role="button"
             tabIndex={0}
             aria-label={pass.full_name}
@@ -202,8 +206,20 @@ export function AdminGuestPassListPage() {
             }}
           >
             <CardContent className="p-5 flex flex-col h-full">
+              {pass.out_of_schedule && (
+                <div className="mb-3 rounded-md border border-red-200 bg-red-100 px-2 py-1 text-[11px] font-semibold text-red-700">
+                  Fuera de horario
+                </div>
+              )}
+
               <div className="flex items-start justify-between gap-2 mb-3">
-                <span className="font-bold text-gray-900 group-hover:text-purple-700 transition-colors line-clamp-1 flex-1">
+                <span
+                  className={`font-bold transition-colors line-clamp-1 flex-1 ${
+                    pass.out_of_schedule
+                      ? "text-red-900 group-hover:text-red-800"
+                      : "text-gray-900 group-hover:text-purple-700"
+                  }`}
+                >
                   {pass.full_name}
                 </span>
                 <Badge className={`${STATUS_BADGE[pass.status ?? ""]} whitespace-nowrap shrink-0`}>

--- a/frontend/src/pages/Visitors/__tests__/AdminGuestPassList.test.tsx
+++ b/frontend/src/pages/Visitors/__tests__/AdminGuestPassList.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../../../services/guestPasses', () => ({
       created_at: '2024-05-30T09:00:00Z',
       status: 'ACTIVE',
       comment: 'Visita familiar',
+      out_of_schedule: true,
     },
     {
       id: 2,
@@ -27,6 +28,7 @@ vi.mock('../../../services/guestPasses', () => ({
       created_at: '2024-05-31T09:00:00Z',
       status: 'USED',
       comment: '',
+      out_of_schedule: false,
     },
   ]),
   GuestPassApiError: class GuestPassApiError extends Error {},
@@ -126,5 +128,12 @@ describe('AdminGuestPassListPage — [NX-S2.39 / NX-S2.40]', () => {
       const dialog = screen.getByRole('dialog')
       expect(within(dialog).getByText(/Visita familiar/i)).toBeInTheDocument()
     })
+  })
+
+  it('resalta en rojo los pases fuera de horario', async () => {
+    render(<AdminGuestPassListPage />)
+    await waitFor(() => screen.getByText('Juan Pérez'))
+
+    expect(screen.getByText('Fuera de horario')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Como administrador quiero que me notifique que quedan visitantes dentro de la residencia fuera de horario (pasada la hora de salida). 

Para probar esta funcionalidad, hay que crea un pase de visitante como residente fuera del horario de visitas permitido, comprobar que al admin le llega una notificación indicando que X estudiante tiene un visitante con el pase activo fuera del horario, quedándose dicha notificación activa hasta que el pase sea cancelado. 

Además hay que probar los test de la carpeta guests, ya que he añadido algunos test.

Y por último, para que quede mejor estéticamente y más visual, como admin al meterte en el apartado de visitantes, en el caso de que exista algún pase activo fuera del horario, dicho pase debe salir en rojo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Nuevas Funcionalidades**
  * Los administradores ahora pueden ver notificaciones de pases de visitantes después del horario de visita configurado.
  * Los pases de visitante fuera de horario se destacan visualmente en rojo en la interfaz de administración.
  * Nueva categoría de notificaciones de "Visitantes" integrada en el panel de administración.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->