### PR TITLE
fix: nx s3.99 failure conditions eservas

### DIFF
--- a/frontend/src/pages/Reservations/AdminSpaces.tsx
+++ b/frontend/src/pages/Reservations/AdminSpaces.tsx
@@ -89,7 +89,7 @@ function SpaceCard({
         </div>
       </div>
 
-      <div className="flex gap-2 flex-wrap">
+      <div className="relative z-20 flex gap-2 flex-wrap">
         <Button className="pointer-events-auto" variant="outline" size="sm" onClick={() => onViewReservations(space)}>
           Ver reservas
         </Button>

--- a/frontend/src/pages/Reservations/__tests__/AdminSpaces.test.tsx
+++ b/frontend/src/pages/Reservations/__tests__/AdminSpaces.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AdminSpaces } from '../AdminSpaces'
+import { listAdminSpaces, listSpaceReservations } from '../../../services/adminSpaces'
+
+vi.mock('../../../services/adminSpaces', () => ({
+  listAdminSpaces: vi.fn(),
+  listSpaceReservations: vi.fn(),
+  createSpace: vi.fn(),
+  updateSpace: vi.fn(),
+  deactivateSpace: vi.fn(),
+  getSpace: vi.fn(),
+}))
+
+vi.mock('../../../services/reservations', () => ({
+  isApiError: vi.fn(() => false),
+}))
+
+vi.mock('../components/SpaceFormSheet', () => ({
+  SpaceFormSheet: () => null,
+}))
+
+vi.mock('../components/SpaceReservationsDrawer', () => ({
+  SpaceReservationsDrawer: ({ open, space }: { open: boolean; space: { name: string } | null }) =>
+    open && space ? <div data-testid="space-reservations-drawer">Reservas de {space.name}</div> : null,
+}))
+
+vi.mock('../components/SpaceDetailModal', () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="space-detail-modal">Detalle</div> : null),
+}))
+
+describe('AdminSpaces — [T12]', () => {
+  const mockedListAdminSpaces = vi.mocked(listAdminSpaces)
+  const mockedListSpaceReservations = vi.mocked(listSpaceReservations)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedListAdminSpaces.mockResolvedValue([
+      {
+        id: 7,
+        name: 'Sala Estudio',
+        description: 'Sala para trabajo colaborativo',
+        img: null,
+        capacity: 12,
+        is_active: true,
+        open_time: '08:00:00',
+        close_time: '22:00:00',
+        reservation_interval_minutes: 60,
+      },
+    ])
+    mockedListSpaceReservations.mockResolvedValue([])
+  })
+
+  it('mantiene la fila de acciones por encima del overlay de detalle', async () => {
+    render(<AdminSpaces />)
+
+    const viewReservationsButton = await screen.findByRole('button', { name: 'Ver reservas' })
+    const actionsRow = viewReservationsButton.parentElement
+
+    expect(actionsRow).not.toBeNull()
+    expect(actionsRow).toHaveClass('relative')
+    expect(actionsRow).toHaveClass('z-20')
+  })
+
+  it("abre reservas al pulsar 'Ver reservas' y no el detalle", async () => {
+    const user = userEvent.setup()
+    render(<AdminSpaces />)
+
+    const viewReservationsButton = await screen.findByRole('button', { name: 'Ver reservas' })
+    await user.click(viewReservationsButton)
+
+    await waitFor(() => {
+      expect(mockedListSpaceReservations).toHaveBeenCalledWith(7, 'active')
+    })
+    expect(screen.getByTestId('space-reservations-drawer')).toBeInTheDocument()
+    expect(screen.queryByTestId('space-detail-modal')).toBeNull()
+  })
+})


### PR DESCRIPTION
This pull request improves the UI layering and test coverage for the `AdminSpaces` page. The main change ensures that the action row containing the "Ver reservas" button appears above any overlay, and new tests verify this behavior and related interactions.

UI Layering Fixes:

* Added `relative` and `z-20` classes to the action row in `SpaceCard` to ensure it displays above overlays.

Testing Improvements:

* Added a new test file `AdminSpaces.test.tsx`:
  - Mocks dependencies and components to isolate testing of `AdminSpaces`.
  - Verifies that the action row has the correct CSS classes for layering.
  - Tests that clicking "Ver reservas" opens the reservations drawer and not the detail modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corregida la visualización de los botones de acciones en espacios para asegurar que se muestren correctamente sobre otros elementos superpuestos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->