### PR TITLE
fix: corregir y añadir validaciones en formulario Avisos

### DIFF
--- a/backend/apps/announcements/serializers.py
+++ b/backend/apps/announcements/serializers.py
@@ -3,6 +3,9 @@ from django.utils import timezone
 from .models import Announcement
 
 
+TITLE_MAX_LENGTH = 50
+DESCRIPTION_MAX_LENGTH = 255
+
 COMMON_READ_ONLY_FIELDS = [
     'id',
     'publication_date',
@@ -18,6 +21,22 @@ COMMON_READ_ONLY_FIELDS = [
 class AnnouncementSerializer(serializers.ModelSerializer):
     """Serializer completo para el modelo Announcement."""
 
+    title = serializers.CharField(
+        max_length=TITLE_MAX_LENGTH,
+        error_messages={
+            'required': 'El título es obligatorio',
+            'blank': 'El título no puede estar vacío',
+            'max_length': f'El título no puede contener más de {TITLE_MAX_LENGTH} caracteres.',
+        },
+    )
+    description = serializers.CharField(
+        max_length=DESCRIPTION_MAX_LENGTH,
+        error_messages={
+            'required': 'La descripción es obligatoria',
+            'blank': 'La descripción no puede estar vacía',
+            'max_length': f'La descripción no puede contener más de {DESCRIPTION_MAX_LENGTH} caracteres.',
+        },
+    )
     category_display = serializers.CharField(source='get_category_display', read_only=True)
     has_passed = serializers.BooleanField(read_only=True)
     created_by_name = serializers.SerializerMethodField(read_only=True)
@@ -43,12 +62,6 @@ class AnnouncementSerializer(serializers.ModelSerializer):
         read_only_fields = COMMON_READ_ONLY_FIELDS
 
         extra_kwargs = {
-            'title': {
-                'error_messages': {
-                    'required': 'El título es obligatorio',
-                    'blank': 'El título no puede estar vacío'
-                }
-            },
             'announcement_date': {
                 'error_messages': {
                     'required': 'La fecha del aviso es obligatoria',
@@ -60,12 +73,6 @@ class AnnouncementSerializer(serializers.ModelSerializer):
                     'invalid_choice': 'Categoría no válida. Opciones: URGENT, MAINTENANCE, EVENT, GENERAL'
                 }
             },
-            'description': {
-                'error_messages': {
-                    'required': 'La descripción es obligatoria',
-                    'blank': 'La descripción no puede estar vacía'
-                }
-            }
         }
 
     def get_created_by_name(self, obj):
@@ -75,7 +82,7 @@ class AnnouncementSerializer(serializers.ModelSerializer):
 
     def validate_announcement_date(self, value):
         if value < timezone.now().date():
-            raise serializers.ValidationError("La fecha del aviso no puede ser anterior a la fecha actual.")
+            raise serializers.ValidationError("La fecha no puede estar en pasado.")
         return value
 
 

--- a/backend/apps/announcements/tests/test_announcements_module.py
+++ b/backend/apps/announcements/tests/test_announcements_module.py
@@ -141,7 +141,7 @@ class AnnouncementModuleTests(FastTenantTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["title"][0],
-            "El título no puede contener más de 200 caracteres."
+            "El título no puede contener más de 50 caracteres."
         )
 
     def test_create_announcement_long_description(self):
@@ -160,7 +160,7 @@ class AnnouncementModuleTests(FastTenantTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()["description"][0],
-            "La descripción no puede contener más de 1000 caracteres."
+            "La descripción no puede contener más de 255 caracteres."
         )
 
     def test_create_announcement_past_date(self):

--- a/backend/apps/announcements/tests/test_announcements_module.py
+++ b/backend/apps/announcements/tests/test_announcements_module.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -123,6 +124,63 @@ class AnnouncementModuleTests(FastTenantTestCase):
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Announcement.objects.count(), 1)
+
+    def test_create_announcement_long_title(self):
+        """Rechazar títulos que superan el límite permitido"""
+        data = {
+            "title": "A" * 56,
+            "description": "Descripción válida",
+            "category": Announcement.Category.GENERAL,
+            "announcement_date": (timezone.now().date()).isoformat(),
+        }
+        response = self.admin_client.post(
+            "/api/announcements/",
+            data=json.dumps(data),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["title"][0],
+            "El título no puede contener más de 200 caracteres."
+        )
+
+    def test_create_announcement_long_description(self):
+        """Rechazar descripciones que superan el límite permitido"""
+        data = {
+            "title": "Aviso válido",
+            "description": "A" * 1001,
+            "category": Announcement.Category.GENERAL,
+            "announcement_date": (timezone.now().date()).isoformat(),
+        }
+        response = self.admin_client.post(
+            "/api/announcements/",
+            data=json.dumps(data),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["description"][0],
+            "La descripción no puede contener más de 1000 caracteres."
+        )
+
+    def test_create_announcement_past_date(self):
+        """Rechazar avisos con fecha pasada"""
+        data = {
+            "title": "Aviso válido",
+            "description": "Descripción válida",
+            "category": Announcement.Category.GENERAL,
+            "announcement_date": (timezone.now().date() - timedelta(days=1)).isoformat(),
+        }
+        response = self.admin_client.post(
+            "/api/announcements/",
+            data=json.dumps(data),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["announcement_date"][0],
+            "La fecha no puede estar en pasado."
+        )
 
     def test_list_announcements(self):
         """Listar avisos como admin"""

--- a/frontend/src/components/announcement/AnnouncementCard.tsx
+++ b/frontend/src/components/announcement/AnnouncementCard.tsx
@@ -67,10 +67,10 @@ export function AnnouncementCard({
                 </Badge>
               )}
             </div>
-            <h3 className="font-bold text-card-foreground text-base md:text-lg mb-1.5 line-clamp-2">
+            <h3 className="font-bold text-card-foreground text-base md:text-lg mb-1.5 break-words">
               {announcement.title}
             </h3>
-            <p className="text-sm text-muted-foreground mb-2.5">
+            <p className="text-sm text-muted-foreground mb-2.5 break-words">
               {announcement.description}
             </p>
             <div className="flex items-center gap-3 text-xs text-muted-foreground mt-auto pt-2">

--- a/frontend/src/pages/announcements/AdminAnnouncements.tsx
+++ b/frontend/src/pages/announcements/AdminAnnouncements.tsx
@@ -315,6 +315,7 @@ export function AdminAnnouncements() {
               <Input
                 id="title"
                 placeholder="Ej: Corte de agua programado"
+                maxLength={TITLE_MAX_LENGTH}
                 value={newAnnouncement.title}
                 onChange={(e) => {
                   setNewAnnouncement({ ...newAnnouncement, title: e.target.value });
@@ -357,6 +358,7 @@ export function AdminAnnouncements() {
                 id="description"
                 placeholder="Describe el aviso en detalle..."
                 rows={4}
+                maxLength={DESCRIPTION_MAX_LENGTH}
                 value={newAnnouncement.description}
                 onChange={(e) => {
                   setNewAnnouncement({ ...newAnnouncement, description: e.target.value });
@@ -430,6 +432,7 @@ export function AdminAnnouncements() {
                 <Label htmlFor="edit-title">Título *</Label>
                 <Input
                   id="edit-title"
+                  maxLength={TITLE_MAX_LENGTH}
                   value={editingAnnouncement.title}
                   onChange={(e) => {
                     setEditingAnnouncement({
@@ -474,6 +477,7 @@ export function AdminAnnouncements() {
                 <Textarea
                   id="edit-description"
                   rows={4}
+                  maxLength={DESCRIPTION_MAX_LENGTH}
                   value={editingAnnouncement.description}
                     onChange={(e) => {
                       setEditingAnnouncement({

--- a/frontend/src/pages/announcements/AdminAnnouncements.tsx
+++ b/frontend/src/pages/announcements/AdminAnnouncements.tsx
@@ -87,7 +87,8 @@ export function AdminAnnouncements() {
     } else if (field === 'description') {
       if (value.length > DESCRIPTION_MAX_LENGTH) error = `Máximo ${DESCRIPTION_MAX_LENGTH} caracteres.`;
     } else if (field === 'announcement_date') {
-      if (value < todayDate) error = "La fecha no puede estar en pasado.";
+      if (value.trim() === '') error = "La fecha es obligatoria.";
+      else if (value < todayDate) error = "La fecha no puede estar en pasado.";
     }
 
     if (isCreate) {

--- a/frontend/src/pages/announcements/AdminAnnouncements.tsx
+++ b/frontend/src/pages/announcements/AdminAnnouncements.tsx
@@ -20,6 +20,8 @@ const CATEGORY_OPTIONS: { value: AnnouncementCategory; label: string }[] = [
 ];
 
 const ANNOUNCEMENTS_POLL_MS = 2000;
+const TITLE_MAX_LENGTH = 50;
+const DESCRIPTION_MAX_LENGTH = 255;
 
 const EMPTY_ANNOUNCEMENT_FORM = {
   title: "",
@@ -36,9 +38,7 @@ function getLocalDateString(date: Date = new Date()) {
   return `${year}-${month}-${day}`;
 }
 
-function hasRequiredAnnouncementFields(data: { title: string; description: string; announcement_date: string }) {
-  return Boolean(data.title.trim() && data.description.trim() && data.announcement_date);
-}
+type AnnouncementFormErrors = Partial<Record<"title" | "description" | "announcement_date", string>>;
 
 export function AdminAnnouncements() {
   const [announcements, setAnnouncements] = useState<AnnouncementList[]>([]);
@@ -46,7 +46,6 @@ export function AdminAnnouncements() {
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [error, setError] = useState<string | null>(null);
   
-  // Estados para diálogos
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -55,6 +54,8 @@ export function AdminAnnouncements() {
   const [deletingAnnouncement, setDeletingAnnouncement] = useState<AnnouncementList | null>(null);
   
   const [newAnnouncement, setNewAnnouncement] = useState(EMPTY_ANNOUNCEMENT_FORM);
+  const [createErrors, setCreateErrors] = useState<AnnouncementFormErrors>({});
+  const [editErrors, setEditErrors] = useState<AnnouncementFormErrors>({});
 
   // Estadísticas
   const [stats, setStats] = useState({
@@ -65,17 +66,42 @@ export function AdminAnnouncements() {
 
   const todayDate = getLocalDateString();
 
-  const isPastDate = (dateValue: string) => {
-    if (!dateValue) return false;
+  const validateForm = (data: typeof EMPTY_ANNOUNCEMENT_FORM) => {
+    const errors: AnnouncementFormErrors = {};
+    if (!data.title.trim()) errors.title = "El título es obligatorio.";
+    else if (data.title.length > TITLE_MAX_LENGTH) errors.title = `Máximo ${TITLE_MAX_LENGTH} caracteres.`;
 
-    const normalizedDate = dateValue.slice(0, 10);
-    return normalizedDate < todayDate;
+    if (!data.description.trim()) errors.description = "La descripción es obligatoria.";
+    else if (data.description.length > DESCRIPTION_MAX_LENGTH) errors.description = `Máximo ${DESCRIPTION_MAX_LENGTH} caracteres.`;
+
+    if (!data.announcement_date) errors.announcement_date = "La fecha es obligatoria.";
+    else if (data.announcement_date < todayDate) errors.announcement_date = "La fecha no puede estar en pasado.";
+
+    return errors;
   };
 
-  const loadAnnouncements = useCallback(async (silent = false) => {
-    if (!silent) {
-      setLoading(true);
+  const validateField = (field: 'title' | 'description' | 'announcement_date', value: string, isCreate: boolean) => {
+    let error = '';
+    if (field === 'title') {
+      if (value.length > TITLE_MAX_LENGTH) error = `Máximo ${TITLE_MAX_LENGTH} caracteres.`;
+    } else if (field === 'description') {
+      if (value.length > DESCRIPTION_MAX_LENGTH) error = `Máximo ${DESCRIPTION_MAX_LENGTH} caracteres.`;
+    } else if (field === 'announcement_date') {
+      if (value < todayDate) error = "La fecha no puede estar en pasado.";
     }
+
+    if (isCreate) {
+      setCreateErrors(prev => ({ ...prev, [field]: error }));
+    } else {
+      setEditErrors(prev => ({ ...prev, [field]: error }));
+    }
+  };
+
+  const canCreate = Object.keys(validateForm(newAnnouncement)).length === 0;
+  const canSave = editingAnnouncement ? Object.keys(validateForm(editingAnnouncement as typeof EMPTY_ANNOUNCEMENT_FORM)).length === 0 : false;
+
+  const loadAnnouncements = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
     setError(null);
     try {
       const data = await announcementService.getAnnouncementsByCategory(selectedCategory);
@@ -85,21 +111,9 @@ export function AdminAnnouncements() {
       setError("Error al cargar los avisos");
       console.error(err);
     } finally {
-      if (!silent) {
-        setLoading(false);
-      }
+      if (!silent) setLoading(false);
     }
   }, [selectedCategory]);
-
-  useEffect(() => {
-    loadAnnouncements(false);
-
-    const intervalId = window.setInterval(() => {
-      loadAnnouncements(true);
-    }, ANNOUNCEMENTS_POLL_MS);
-
-    return () => window.clearInterval(intervalId);
-  }, [loadAnnouncements]);
 
   const calculateStats = (data: AnnouncementList[]) => {
     const now = new Date();
@@ -122,42 +136,39 @@ export function AdminAnnouncements() {
     });
   };
 
-  const handleCreateAnnouncement = async () => {
-    if (!hasRequiredAnnouncementFields(newAnnouncement)) {
-      toast.error("Por favor, completa todos los campos obligatorios");
-      return;
-    }
+  useEffect(() => {
+    loadAnnouncements(false);
+    const intervalId = window.setInterval(() => loadAnnouncements(true), ANNOUNCEMENTS_POLL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [loadAnnouncements]);
 
-    if (isPastDate(newAnnouncement.announcement_date)) {
-      toast.error("La fecha del aviso no puede ser anterior a hoy");
-      return;
-    }
+  const handleCreateAnnouncement = async () => {
+    const errors = validateForm(newAnnouncement);
+    setCreateErrors(errors);
+    if (Object.keys(errors).length) return;
 
     try {
       await announcementService.createAnnouncement(newAnnouncement);
-      
       toast.success("Aviso publicado correctamente");
       setIsCreateDialogOpen(false);
       setNewAnnouncement(EMPTY_ANNOUNCEMENT_FORM);
       loadAnnouncements();
     } catch (err) {
-      toast.error("Error al crear el aviso");
-      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Error al crear el aviso");
     }
   };
 
   const handleEditAnnouncement = async () => {
     if (!editingAnnouncement) return;
-
-    if (!hasRequiredAnnouncementFields(editingAnnouncement)) {
-      toast.error("Por favor, completa todos los campos obligatorios");
-      return;
-    }
-
-    if (isPastDate(editingAnnouncement.announcement_date)) {
-      toast.error("La fecha del aviso no puede ser anterior a hoy");
-      return;
-    }
+    const errors = validateForm({
+      title: editingAnnouncement.title,
+      description: editingAnnouncement.description,
+      category: editingAnnouncement.category,
+      announcement_date: editingAnnouncement.announcement_date,
+      featured: editingAnnouncement.featured,
+    });
+    setEditErrors(errors);
+    if (Object.keys(errors).length) return;
 
     try {
       await announcementService.updateAnnouncement(editingAnnouncement.id, {
@@ -166,25 +177,17 @@ export function AdminAnnouncements() {
         category: editingAnnouncement.category,
         announcement_date: editingAnnouncement.announcement_date,
       });
-      
       toast.success("Aviso actualizado correctamente");
       setIsEditDialogOpen(false);
       setEditingAnnouncement(null);
       loadAnnouncements();
     } catch (err) {
-      toast.error("Error al actualizar el aviso");
-      console.error(err);
+      toast.error(err instanceof Error ? err.message : "Error al actualizar el aviso");
     }
-  };
-
-  const openDeleteDialog = (announcement: AnnouncementList) => {
-    setDeletingAnnouncement(announcement);
-    setIsDeleteDialogOpen(true);
   };
 
   const handleDeleteAnnouncement = async () => {
     if (!deletingAnnouncement) return;
-
     setIsDeleting(true);
     try {
       await announcementService.deleteAnnouncement(deletingAnnouncement.id);
@@ -194,15 +197,9 @@ export function AdminAnnouncements() {
       loadAnnouncements();
     } catch (err) {
       toast.error("Error al eliminar el aviso");
-      console.error(err);
     } finally {
       setIsDeleting(false);
     }
-  };
-
-  const openEditDialog = (announcement: AnnouncementList) => {
-    setEditingAnnouncement(announcement);
-    setIsEditDialogOpen(true);
   };
 
   return (
@@ -217,7 +214,11 @@ export function AdminAnnouncements() {
           </div>
           <Button 
             className="bg-primary hover:bg-primary/90 text-primary-foreground"
-            onClick={() => setIsCreateDialogOpen(true)}
+            onClick={() => {
+              setNewAnnouncement(EMPTY_ANNOUNCEMENT_FORM);
+              setCreateErrors({});
+              setIsCreateDialogOpen(true);
+            }}
           >
             <Plus className="w-4 h-4 mr-2" />
             Nuevo Aviso
@@ -276,8 +277,15 @@ export function AdminAnnouncements() {
                 key={announcement.id}
                 announcement={announcement}
                 showControls={true}
-                onEdit={() => openEditDialog(announcement)}
-                onDelete={() => openDeleteDialog(announcement)}
+                onEdit={() => {
+                  setEditingAnnouncement(announcement);
+                  setEditErrors({});
+                  setIsEditDialogOpen(true);
+                }}
+                onDelete={() => {
+                  setDeletingAnnouncement(announcement);
+                  setIsDeleteDialogOpen(true);
+                }}
               />
             ))}
           </div>
@@ -285,7 +293,13 @@ export function AdminAnnouncements() {
       </div>
 
       {/* Form Crear Aviso */}
-      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+      <Dialog open={isCreateDialogOpen} onOpenChange={(open) => {
+        if (!open) {
+          setIsCreateDialogOpen(false);
+          setNewAnnouncement(EMPTY_ANNOUNCEMENT_FORM);
+          setCreateErrors({});
+        }
+      }}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Crear Nuevo Aviso</DialogTitle>
@@ -295,17 +309,30 @@ export function AdminAnnouncements() {
           </DialogHeader>
           
           <div className="space-y-4 py-4">
-            <div className="space-y-2">
+            <div>
               <Label htmlFor="title">Título *</Label>
               <Input
                 id="title"
                 placeholder="Ej: Corte de agua programado"
                 value={newAnnouncement.title}
-                onChange={(e) => setNewAnnouncement({ ...newAnnouncement, title: e.target.value })}
+                onChange={(e) => {
+                  setNewAnnouncement({ ...newAnnouncement, title: e.target.value });
+                  validateField('title', e.target.value, true);
+                }}
               />
+              <div className="flex items-center justify-between mt-1">
+                {createErrors.title ? (
+                  <p className="text-sm text-destructive">{createErrors.title}</p>
+                ) : (
+                  <div />
+                )}
+                <div className={`text-xs ${createErrors.title ? 'text-destructive' : 'text-muted-foreground'}`}>
+                  {newAnnouncement.title.length}/{TITLE_MAX_LENGTH}
+                </div>
+              </div>
             </div>
 
-            <div className="space-y-2">
+            <div>
               <Label htmlFor="category">Categoría *</Label>
               <Select
                 value={newAnnouncement.category}
@@ -323,27 +350,44 @@ export function AdminAnnouncements() {
               </Select>
             </div>
 
-            <div className="space-y-2">
+            <div>
               <Label htmlFor="description">Descripción *</Label>
               <Textarea
                 id="description"
                 placeholder="Describe el aviso en detalle..."
                 rows={4}
                 value={newAnnouncement.description}
-                onChange={(e) => setNewAnnouncement({ ...newAnnouncement, description: e.target.value })}
+                onChange={(e) => {
+                  setNewAnnouncement({ ...newAnnouncement, description: e.target.value });
+                  validateField('description', e.target.value, true);
+                }}
                 required
               />
+              <div className="flex items-center justify-between mt-1">
+                {createErrors.description ? (
+                  <p className="text-sm text-destructive">{createErrors.description}</p>
+                ) : (
+                  <div />
+                )}
+                <div className={`text-xs ${createErrors.description ? 'text-destructive' : 'text-muted-foreground'}`}>
+                  {newAnnouncement.description.length}/{DESCRIPTION_MAX_LENGTH}
+                </div>
+              </div>
             </div>
 
-            <div className="space-y-2">
+            <div>
               <Label htmlFor="date">Fecha del aviso *</Label>
               <Input
                 id="date"
                 type="date"
                 min={todayDate}
                 value={newAnnouncement.announcement_date}
-                onChange={(e) => setNewAnnouncement({ ...newAnnouncement, announcement_date: e.target.value })}
+                onChange={(e) => {
+                  setNewAnnouncement({ ...newAnnouncement, announcement_date: e.target.value });
+                  validateField('announcement_date', e.target.value, true);
+                }}
               />
+              {createErrors.announcement_date && <p className="text-sm text-destructive mt-1">{createErrors.announcement_date}</p>}
             </div>
           </div>
 
@@ -352,8 +396,9 @@ export function AdminAnnouncements() {
               Cancelar
             </Button>
             <Button
-              className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              className={`bg-primary hover:bg-primary/90 text-primary-foreground ${!canCreate ? 'opacity-50 cursor-not-allowed' : ''}`}
               onClick={handleCreateAnnouncement}
+              disabled={!canCreate}
             >
               <Plus className="w-4 h-4 mr-2" />
               Publicar Aviso
@@ -363,7 +408,13 @@ export function AdminAnnouncements() {
       </Dialog>
 
       {/* Diálogo Editar Aviso */}
-      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+      <Dialog open={isEditDialogOpen} onOpenChange={(open) => {
+        if (!open) {
+          setIsEditDialogOpen(false);
+          setEditingAnnouncement(null);
+          setEditErrors({});
+        }
+      }}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Editar Aviso</DialogTitle>
@@ -374,19 +425,32 @@ export function AdminAnnouncements() {
 
           {editingAnnouncement && (
             <div className="space-y-4 py-4">
-              <div className="space-y-2">
+              <div>
                 <Label htmlFor="edit-title">Título *</Label>
                 <Input
                   id="edit-title"
                   value={editingAnnouncement.title}
-                  onChange={(e) => setEditingAnnouncement({
-                    ...editingAnnouncement,
-                    title: e.target.value
-                  })}
+                  onChange={(e) => {
+                    setEditingAnnouncement({
+                      ...editingAnnouncement,
+                      title: e.target.value
+                    });
+                    validateField('title', e.target.value, false);
+                  }}
                 />
+                <div className="flex items-center justify-between mt-1">
+                  {editErrors.title ? (
+                    <p className="text-sm text-destructive">{editErrors.title}</p>
+                  ) : (
+                    <div />
+                  )}
+                  <div className={`text-xs ${editErrors.title ? 'text-destructive' : 'text-muted-foreground'}`}>
+                    {editingAnnouncement.title.length}/{TITLE_MAX_LENGTH}
+                  </div>
+                </div>
               </div>
 
-              <div className="space-y-2">
+              <div>
                 <Label htmlFor="edit-category">Categoría *</Label>
                 <Select
                   value={editingAnnouncement.category}
@@ -404,32 +468,49 @@ export function AdminAnnouncements() {
                 </Select>
               </div>
 
-              <div className="space-y-2">
+              <div>
                 <Label htmlFor="edit-description">Descripción *</Label>
                 <Textarea
                   id="edit-description"
                   rows={4}
                   value={editingAnnouncement.description}
-                  onChange={(e) => setEditingAnnouncement({
-                    ...editingAnnouncement,
-                    description: e.target.value
-                  })}
+                    onChange={(e) => {
+                      setEditingAnnouncement({
+                        ...editingAnnouncement,
+                        description: e.target.value
+                      });
+                      validateField('description', e.target.value, false);
+                    }}
                   required
                 />
+                <div className="flex items-center justify-between mt-1">
+                  {editErrors.description ? (
+                    <p className="text-sm text-destructive">{editErrors.description}</p>
+                  ) : (
+                    <div />
+                  )}
+                  <div className={`text-xs ${editErrors.description ? 'text-destructive' : 'text-muted-foreground'}`}>
+                    {editingAnnouncement.description.length}/{DESCRIPTION_MAX_LENGTH}
+                  </div>
+                </div>
               </div>
 
-              <div className="space-y-2">
+              <div>
                 <Label htmlFor="edit-date">Fecha del aviso *</Label>
                 <Input
                   id="edit-date"
                   type="date"
                   min={todayDate}
                   value={editingAnnouncement.announcement_date}
-                  onChange={(e) => setEditingAnnouncement({
-                    ...editingAnnouncement,
-                    announcement_date: e.target.value
-                  })}
+                    onChange={(e) => {
+                      setEditingAnnouncement({
+                        ...editingAnnouncement,
+                        announcement_date: e.target.value
+                      });
+                      validateField('announcement_date', e.target.value, false);
+                    }}
                 />
+                {editErrors.announcement_date && <p className="text-sm text-destructive mt-1">{editErrors.announcement_date}</p>}
               </div>
             </div>
           )}
@@ -439,8 +520,9 @@ export function AdminAnnouncements() {
               Cancelar
             </Button>
             <Button 
-              className="bg-primary hover:bg-primary/90 text-primary-foreground"
+              className={`bg-primary hover:bg-primary/90 text-primary-foreground ${!canSave ? 'opacity-50 cursor-not-allowed' : ''}`}
               onClick={handleEditAnnouncement}
+              disabled={!canSave}
             >
               Guardar Cambios
             </Button>


### PR DESCRIPTION
Comprobar en el formulario, que saltan las validaciones cuando se superan los caracteres, además de inhabilitarse el botón de publicar aviso.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Nuevas Características**
  * Validación mejorada en formularios de creación y edición de anuncios con mensajes de error en español
  * Límites de caracteres: 50 caracteres para título y 255 para descripción
  * Validación en tiempo real que desactiva el botón de guardar cuando el formulario no es válido

* **Correcciones de Errores**
  * Mejora en la visualización del texto de anuncios con saltos de línea adecuados

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ispp-g7-nexus/7-NexUS/pull/764)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->